### PR TITLE
Use `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ include = ["src/", "license"]
 
 [dependencies]
 markdown = "1.0.0-alpha.2"
-swc_common = "0.29"
-swc_ecma_ast = "0.94"
-swc_ecma_parser = "0.122"
-swc_ecma_codegen = "0.127"
-swc_ecma_visit = "0.80"
+swc_core = { features = [
+  "ecma_ast",
+  "ecma_visit",
+  "ecma_codegen",
+  "ecma_parser",
+  "common",
+], version = "0.40.16" }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -3,7 +3,6 @@
 //! Port of <https://github.com/mdx-js/mdx/blob/main/packages/mdx/lib/plugin/recma-document.js>,
 //! by the same author.
 
-extern crate swc_ecma_ast;
 use crate::hast_util_to_swc::Program;
 use crate::swc_utils::{
     bytepos_to_point, create_call_expression, create_ident, create_ident_expression,
@@ -14,7 +13,7 @@ use markdown::{
     unist::{Point, Position},
     Location,
 };
-use swc_ecma_ast::{
+use swc_core::ecma::ast::{
     AssignPat, BindingIdent, BlockStmt, Callee, CondExpr, Decl, DefaultDecl, ExportDefaultExpr,
     ExportSpecifier, Expr, ExprOrSpread, FnDecl, Function, ImportDecl, ImportDefaultSpecifier,
     ImportNamedSpecifier, ImportSpecifier, JSXAttrOrSpread, JSXClosingElement, JSXElement,
@@ -127,10 +126,10 @@ pub fn mdx_plugin_recma_document(
         if !pragmas.is_empty() {
             program.comments.insert(
                 0,
-                swc_common::comments::Comment {
-                    kind: swc_common::comments::CommentKind::Block,
+                swc_core::common::comments::Comment {
+                    kind: swc_core::common::comments::CommentKind::Block,
                     text: pragmas.join(" ").into(),
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                 },
             );
         }
@@ -149,7 +148,7 @@ pub fn mdx_plugin_recma_document(
         replacements.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
             specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
                 local: create_ident(sym),
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             })],
             src: Box::new(create_str(
                 if let Some(source) = &options.pragma_import_source {
@@ -160,7 +159,7 @@ pub fn mdx_plugin_recma_document(
             )),
             type_only: false,
             asserts: None,
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         })));
     }
 
@@ -276,13 +275,13 @@ pub fn mdx_plugin_recma_document(
                             specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
                                 local: create_ident("MDXLayout"),
                                 imported: Some(ModuleExportName::Ident(id)),
-                                span: swc_common::DUMMY_SP,
+                                span: swc_core::common::DUMMY_SP,
                                 is_type_only: false,
                             })],
                             src: source,
                             type_only: false,
                             asserts: None,
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         })));
                     }
                     // It’s an `export {x}`, so generate a variable declaration.
@@ -365,7 +364,7 @@ pub fn mdx_plugin_recma_document(
     replacements.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
         ExportDefaultExpr {
             expr: Box::new(create_ident_expression("MDXContent")),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         },
     )));
 
@@ -383,16 +382,16 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
         opening: JSXOpeningElement {
             name: JSXElementName::Ident(create_ident("MDXLayout")),
             attrs: vec![JSXAttrOrSpread::SpreadElement(SpreadElement {
-                dot3_token: swc_common::DUMMY_SP,
+                dot3_token: swc_core::common::DUMMY_SP,
                 expr: Box::new(create_ident_expression("props")),
             })],
             self_closing: false,
             type_args: None,
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         },
         closing: Some(JSXClosingElement {
             name: JSXElementName::Ident(create_ident("MDXLayout")),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         }),
         // ```jsx
         // <_createMdxContent {...props} />
@@ -401,18 +400,18 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
             opening: JSXOpeningElement {
                 name: JSXElementName::Ident(create_ident("_createMdxContent")),
                 attrs: vec![JSXAttrOrSpread::SpreadElement(SpreadElement {
-                    dot3_token: swc_common::DUMMY_SP,
+                    dot3_token: swc_core::common::DUMMY_SP,
                     expr: Box::new(create_ident_expression("props")),
                 })],
                 self_closing: true,
                 type_args: None,
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             },
             closing: None,
             children: vec![],
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         }))],
-        span: swc_common::DUMMY_SP,
+        span: swc_core::common::DUMMY_SP,
     }));
 
     if !has_internal_layout {
@@ -429,7 +428,7 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                     expr: Box::new(create_ident_expression("props")),
                 }],
             )),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         });
     }
 
@@ -448,21 +447,21 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                     type_ann: None,
                 }),
                 decorators: vec![],
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             }],
             decorators: vec![],
             body: Some(BlockStmt {
                 stmts: vec![Stmt::Return(ReturnStmt {
                     arg: Some(Box::new(expr.unwrap_or_else(create_null_expression))),
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                 })],
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         }),
     })));
 
@@ -482,25 +481,25 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                         type_ann: None,
                     })),
                     right: Box::new(create_object_expression(vec![])),
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     type_ann: None,
                 }),
                 decorators: vec![],
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             }],
             decorators: vec![],
             body: Some(BlockStmt {
                 stmts: vec![Stmt::Return(ReturnStmt {
                     arg: Some(Box::new(result)),
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                 })],
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
         }),
     })));
 
@@ -521,10 +520,10 @@ fn create_layout_decl(expr: Expr) -> ModuleItem {
                 type_ann: None,
             }),
             init: Some(Box::new(expr)),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
             definite: false,
         }],
-        span: swc_common::DUMMY_SP,
+        span: swc_core::common::DUMMY_SP,
     }))))
 }
 
@@ -557,7 +556,7 @@ mod tests {
     use crate::swc_utils::create_bool_expression;
     use markdown::{to_mdast, ParseOptions};
     use pretty_assertions::assert_eq;
-    use swc_ecma_ast::{
+    use swc_core::ecma::ast::{
         EmptyStmt, ExportDefaultDecl, ExprStmt, JSXClosingFragment, JSXFragment,
         JSXOpeningFragment, JSXText, Module, TsInterfaceBody, TsInterfaceDecl, WhileStmt,
     };
@@ -821,21 +820,21 @@ export default MDXContent;
                     path: None,
                     comments: vec![],
                     module: Module {
-                        span: swc_common::DUMMY_SP,
+                        span: swc_core::common::DUMMY_SP,
                         shebang: None,
                         body: vec![ModuleItem::ModuleDecl(
                             ModuleDecl::ExportDefaultDecl(
                                 ExportDefaultDecl {
-                                    span: swc_common::DUMMY_SP,
+                                    span: swc_core::common::DUMMY_SP,
                                     decl: DefaultDecl::TsInterfaceDecl(Box::new(
                                         TsInterfaceDecl {
-                                            span: swc_common::DUMMY_SP,
+                                            span: swc_core::common::DUMMY_SP,
                                             id: create_ident("a"),
                                             declare: true,
                                             type_params: None,
                                             extends: vec![],
                                             body: TsInterfaceBody {
-                                                span: swc_common::DUMMY_SP,
+                                                span: swc_core::common::DUMMY_SP,
                                                 body: vec![]
                                             }
                                         }
@@ -861,13 +860,13 @@ export default MDXContent;
             path: None,
             comments: vec![],
             module: Module {
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
                 shebang: None,
                 body: vec![ModuleItem::Stmt(Stmt::While(WhileStmt {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     test: Box::new(create_bool_expression(true)),
                     body: Box::new(Stmt::Empty(EmptyStmt {
-                        span: swc_common::DUMMY_SP,
+                        span: swc_core::common::DUMMY_SP,
                     })),
                 }))],
             },
@@ -898,10 +897,10 @@ export default MDXContent;
             path: None,
             comments: vec![],
             module: Module {
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
                 shebang: None,
                 body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     expr: Box::new(create_bool_expression(true)),
                 }))],
             },
@@ -932,21 +931,21 @@ export default MDXContent;
             path: None,
             comments: vec![],
             module: Module {
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
                 shebang: None,
                 body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     expr: Box::new(Expr::JSXFragment(JSXFragment {
-                        span: swc_common::DUMMY_SP,
+                        span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningFragment {
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         },
                         closing: JSXClosingFragment {
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         },
                         children: vec![JSXElementChild::JSXText(JSXText {
                             value: "a".into(),
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                             raw: "a".into(),
                         })],
                     })),
@@ -978,26 +977,26 @@ export default MDXContent;
             path: None,
             comments: vec![],
             module: Module {
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
                 shebang: None,
                 body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     expr: Box::new(Expr::JSXElement(Box::new(JSXElement {
-                        span: swc_common::DUMMY_SP,
+                        span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningElement {
                             name: JSXElementName::Ident(create_ident("a")),
                             attrs: vec![],
                             self_closing: false,
                             type_args: None,
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         },
                         closing: Some(JSXClosingElement {
                             name: JSXElementName::Ident(create_ident("a")),
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         }),
                         children: vec![JSXElementChild::JSXText(JSXText {
                             value: "b".into(),
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                             raw: "b".into(),
                         })],
                     }))),

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -3,8 +3,6 @@
 //! Port of <https://github.com/mdx-js/mdx/blob/main/packages/mdx/lib/plugin/recma-jsx-rewrite.js>,
 //! by the same author.
 
-extern crate swc_common;
-extern crate swc_ecma_ast;
 use crate::hast_util_to_swc::{Program, MAGIC_EXPLICIT_MARKER};
 use crate::swc_utils::{
     create_binary_expression, create_bool_expression, create_call_expression, create_ident,
@@ -14,8 +12,8 @@ use crate::swc_utils::{
     jsx_member_to_parts, position_to_string, span_to_position,
 };
 use markdown::{unist::Position, Location};
-use swc_common::{util::take::Take, Span, DUMMY_SP};
-use swc_ecma_ast::{
+use swc_core::common::{util::take::Take, Span, DUMMY_SP};
+use swc_core::ecma::ast::{
     ArrowExpr, AssignPatProp, BinaryOp, BindingIdent, BlockStmt, BlockStmtOrExpr, Callee,
     CatchClause, ClassDecl, CondExpr, Decl, DoWhileStmt, Expr, ExprOrSpread, ExprStmt, FnDecl,
     FnExpr, ForInStmt, ForOfStmt, ForStmt, Function, IfStmt, ImportDecl, ImportNamedSpecifier,
@@ -24,7 +22,7 @@ use swc_ecma_ast::{
     ParenExpr, Pat, Prop, PropOrSpread, ReturnStmt, Stmt, ThrowStmt, UnaryExpr, UnaryOp, VarDecl,
     VarDeclKind, VarDeclarator, WhileStmt,
 };
-use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
+use swc_core::ecma::visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 /// Configuration.
 #[derive(Debug, Default, Clone)]
@@ -1005,7 +1003,7 @@ mod tests {
     use crate::swc_utils::create_jsx_name_from_str;
     use markdown::{to_mdast, Location, ParseOptions};
     use pretty_assertions::assert_eq;
-    use swc_ecma_ast::{Invalid, JSXOpeningElement, Module};
+    use swc_core::ecma::ast::{Invalid, JSXOpeningElement, Module};
 
     fn compile(value: &str, options: &Options, named: bool) -> Result<String, String> {
         let location = Location::new(value.as_bytes());

--- a/src/swc.rs
+++ b/src/swc.rs
@@ -1,27 +1,24 @@
 //! Bridge between `markdown-rs` and SWC.
 
 extern crate markdown;
-extern crate swc_common;
-extern crate swc_ecma_ast;
-extern crate swc_ecma_parser;
 
 use crate::swc_utils::{
     create_span, prefix_error_with_point, DropContext, RewritePrefixContext, RewriteStopsContext,
 };
 use markdown::{mdast::Stop, Location, MdxExpressionKind, MdxSignal};
 use std::rc::Rc;
-use swc_common::{
+use swc_core::common::{
     comments::{Comment, Comments, SingleThreadedComments, SingleThreadedCommentsMap},
     source_map::Pos,
     sync::Lrc,
     BytePos, FileName, FilePathMapping, SourceFile, SourceMap, Span, Spanned,
 };
-use swc_ecma_ast::{EsVersion, Expr, Module, PropOrSpread};
-use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
-use swc_ecma_parser::{
+use swc_core::ecma::ast::{EsVersion, Expr, Module, PropOrSpread};
+use swc_core::ecma::codegen::{text_writer::JsWriter, Emitter};
+use swc_core::ecma::parser::{
     error::Error as SwcError, parse_file_as_expr, parse_file_as_module, EsConfig, Syntax,
 };
-use swc_ecma_visit::VisitMutWith;
+use swc_core::ecma::visit::VisitMutWith;
 
 /// Lex ESM in MDX with SWC.
 pub fn parse_esm(value: &str) -> MdxSignal {
@@ -218,7 +215,7 @@ pub fn serialize(module: &mut Module, comments: Option<&Vec<Comment>>) -> String
     let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
     {
         let mut emitter = Emitter {
-            cfg: swc_ecma_codegen::Config {
+            cfg: swc_core::ecma::codegen::Config {
                 ..Default::default()
             },
             cm: cm.clone(),

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -1,7 +1,5 @@
 //! Turn JSX into function calls.
 
-extern crate swc_common;
-extern crate swc_ecma_ast;
 use crate::hast_util_to_swc::Program;
 use crate::mdx_plugin_recma_document::JsxRuntime;
 use crate::swc_utils::{
@@ -13,17 +11,17 @@ use crate::swc_utils::{
 };
 use core::str;
 use markdown::Location;
-use swc_common::{
+use swc_core::common::{
     comments::{Comment, CommentKind},
     util::take::Take,
 };
-use swc_ecma_ast::{
+use swc_core::ecma::ast::{
     ArrayLit, CallExpr, Callee, Expr, ExprOrSpread, ImportDecl, ImportNamedSpecifier,
     ImportSpecifier, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXElement, JSXElementChild,
     JSXExpr, JSXFragment, KeyValueProp, Lit, ModuleDecl, ModuleExportName, ModuleItem, Prop,
     PropName, PropOrSpread, ThisExpr,
 };
-use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
+use swc_core::ecma::visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 /// Configuration.
 #[derive(Debug, Default, Clone)]
@@ -75,7 +73,7 @@ pub fn swc_util_build_jsx(
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
             local: create_ident("_Fragment"),
             imported: Some(ModuleExportName::Ident(create_ident("Fragment"))),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
     }
@@ -84,7 +82,7 @@ pub fn swc_util_build_jsx(
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
             local: create_ident("_jsx"),
             imported: Some(ModuleExportName::Ident(create_ident("jsx"))),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
     }
@@ -93,7 +91,7 @@ pub fn swc_util_build_jsx(
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
             local: create_ident("_jsxs"),
             imported: Some(ModuleExportName::Ident(create_ident("jsxs"))),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
     }
@@ -102,7 +100,7 @@ pub fn swc_util_build_jsx(
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
             local: create_ident("_jsxDEV"),
             imported: Some(ModuleExportName::Ident(create_ident("jsxDEV"))),
-            span: swc_common::DUMMY_SP,
+            span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
     }
@@ -123,7 +121,7 @@ pub fn swc_util_build_jsx(
                 ))),
                 type_only: false,
                 asserts: None,
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
             })),
         );
     }
@@ -322,7 +320,7 @@ impl<'a> State<'a> {
                 }
                 let lit = ArrayLit {
                     elems: elements,
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                 };
                 Some(Expr::Array(lit))
             };
@@ -371,7 +369,7 @@ impl<'a> State<'a> {
     /// Turn the parsed parts from fragments or elements into a call.
     fn jsx_expressions_to_call(
         &mut self,
-        span: &swc_common::Span,
+        span: &swc_core::common::Span,
         name: Expr,
         attributes: Option<Vec<JSXAttrOrSpread>>,
         mut children: Vec<Expr>,
@@ -473,7 +471,7 @@ impl<'a> State<'a> {
                 // this
                 // ```
                 let this_expression = ThisExpr {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                 };
                 parameters.push(ExprOrSpread {
                     spread: None,
@@ -787,13 +785,14 @@ mod tests {
     use crate::hast_util_to_swc::Program;
     use crate::swc::{flat_comments, serialize};
     use pretty_assertions::assert_eq;
-    use swc_common::comments::SingleThreadedComments;
-    use swc_common::{source_map::Pos, BytePos, FileName, SourceFile};
-    use swc_ecma_ast::{
+    use swc_core::common::{
+        comments::SingleThreadedComments, source_map::Pos, BytePos, FileName, SourceFile,
+    };
+    use swc_core::ecma::ast::{
         EsVersion, ExprStmt, JSXClosingElement, JSXElementName, JSXOpeningElement, JSXSpreadChild,
         Module, Stmt,
     };
-    use swc_ecma_parser::{parse_file_as_module, EsConfig, Syntax};
+    use swc_core::ecma::parser::{parse_file_as_module, EsConfig, Syntax};
 
     fn compile(value: &str, options: &Options) -> Result<String, String> {
         let location = Location::new(value.as_bytes());
@@ -1329,26 +1328,26 @@ _jsx(\"a\", {
             path: None,
             comments: vec![],
             module: Module {
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
                 shebang: None,
                 body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     expr: Box::new(Expr::JSXElement(Box::new(JSXElement {
-                        span: swc_common::DUMMY_SP,
+                        span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningElement {
                             name: JSXElementName::Ident(create_ident("a")),
                             attrs: vec![],
                             self_closing: false,
                             type_args: None,
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         },
                         closing: Some(JSXClosingElement {
                             name: JSXElementName::Ident(create_ident("a")),
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         }),
                         children: vec![JSXElementChild::JSXSpreadChild(JSXSpreadChild {
                             expr: Box::new(create_ident_expression("a")),
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         })],
                     }))),
                 }))],
@@ -1539,18 +1538,18 @@ _jsxDEV(_Fragment, {
             path: None,
             comments: vec![],
             module: Module {
-                span: swc_common::DUMMY_SP,
+                span: swc_core::common::DUMMY_SP,
                 shebang: None,
                 body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    span: swc_common::DUMMY_SP,
+                    span: swc_core::common::DUMMY_SP,
                     expr: Box::new(Expr::JSXElement(Box::new(JSXElement {
-                        span: swc_common::DUMMY_SP,
+                        span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningElement {
                             name: JSXElementName::Ident(create_ident("a")),
                             attrs: vec![],
                             self_closing: true,
                             type_args: None,
-                            span: swc_common::DUMMY_SP,
+                            span: swc_core::common::DUMMY_SP,
                         },
                         closing: None,
                         children: vec![],

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -8,13 +8,13 @@ use markdown::{
     Location,
 };
 
-use swc_common::{BytePos, Span, SyntaxContext, DUMMY_SP};
-use swc_ecma_ast::{
+use swc_core::common::{BytePos, Span, SyntaxContext, DUMMY_SP};
+use swc_core::ecma::ast::{
     BinExpr, BinaryOp, Bool, CallExpr, Callee, ComputedPropName, Expr, ExprOrSpread, Ident,
     JSXAttrName, JSXElementName, JSXMemberExpr, JSXNamespacedName, JSXObject, Lit, MemberExpr,
     MemberProp, Null, Number, ObjectLit, PropName, PropOrSpread, Str,
 };
-use swc_ecma_visit::{noop_visit_mut_type, VisitMut};
+use swc_core::ecma::visit::{noop_visit_mut_type, VisitMut};
 
 /// Turn a unist position, into an SWC span, of two byte positions.
 ///
@@ -220,7 +220,7 @@ pub fn create_ident_expression(sym: &str) -> Expr {
 /// Generate a null.
 pub fn create_null() -> Null {
     Null {
-        span: swc_common::DUMMY_SP,
+        span: swc_core::common::DUMMY_SP,
     }
 }
 


### PR DESCRIPTION
I'm not sure if I'll copy this into or use this pkg directly, but in any case swc_core is a canonical sdk for the swc's features to make easier version management across dependencies.