### PR TITLE
build(cargo): bump up swc_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.3"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.40.16", features = [
+swc_core = { version = "0.43.23", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
This PR bumps up swc_core to near-latest to pick up some changes incomaptible to build next.js.