### PR TITLE
build(cargo): bump up swc_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.4"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.43.23", features = [
+swc_core = { version = "0.44.2", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.4"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.44.2", features = [
+swc_core = { version = "0.44.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -481,7 +481,7 @@ fn err_expression_spread_multi_2() {
 fn err_expression_spread_empty() {
     assert_eq!(
         compile("<a {...} />", &Default::default()),
-        Err("1:12: Could not parse expression with swc: Unexpected token `}`. Expected this, import, async, function, [ for array literal, { for object literal, @ for decorator, function, class, null, true, false, number, bigint, string, regexp, ` for template literal, (, or an identifier".into()),
+        Err("1:12: Could not parse expression with swc: Expression expected".into()),
         "should crash on an empty spread expression",
     );
 }
@@ -490,7 +490,7 @@ fn err_expression_spread_empty() {
 fn err_expression_spread_invalid() {
     assert_eq!(
         compile("<a {...?} />", &Default::default()),
-        Err("1:13: Could not parse expression with swc: Unexpected token `?`. Expected this, import, async, function, [ for array literal, { for object literal, @ for decorator, function, class, null, true, false, number, bigint, string, regexp, ` for template literal, (, or an identifier".into()),
+        Err("1:13: Could not parse expression with swc: Expression expected".into()),
         "should crash on an invalid spread expression",
     );
 }


### PR DESCRIPTION
This PR bumps up swc_core for one another round, which includes fix for critical circular dependency issues for certain cases.