### PR TITLE
Experimental Plugins

### DIFF
--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -1,8 +1,12 @@
 extern crate mdxjs;
 
 use markdown::mdast;
+use mdxjs::hast;
 use mdxjs::{HastNode, MdastNode, Options, PluginOptions, RecmaProgram};
 use std::rc::Rc;
+use swc_core::common::{Span, SyntaxContext};
+use swc_core::ecma::ast as estree;
+use swc_core::ecma::atoms::JsWord;
 
 /// Example that compiles the example MDX document from <https://mdxjs.com>
 /// to JavaScript.
@@ -15,23 +19,37 @@ fn main() -> Result<(), String> {
                 ..Default::default()
             },
             &PluginOptions {
-                experimental_mdast_transforms: Some(vec![Rc::new(|root: &MdastNode| {
-                    let mut root1 = root.clone();
-                    visit_mut(&mut root1, |n| {
-                        match n {
-                            mdast::Node::Text(text) => text.value = "Hello World!".into(),
-                            _ => {}
+                experimental_mdast_transforms: Some(vec![Rc::new(|root: &mut MdastNode| {
+                    mdast_visit_mut(root, |n| {
+                        if let mdast::Node::Text(text) = n {
+                            text.value = "Hello World!".into();
+                        }
+                    });
+                    Ok(())
+                })]),
+                experimental_hast_transforms: Some(vec![Rc::new(|root: &mut HastNode| {
+                    hast_visit_mut(root, |n| {
+                        if let hast::Node::Element(e) = n {
+                            if e.tag_name == "h1" {
+                                e.tag_name = "h2".into();
+                            }
                         };
                     });
-                    root1
+                    Ok(())
                 })]),
-                experimental_hast_transforms: Some(vec![Rc::new(|root: &HastNode| {
-                    root.clone()
-                })]),
-                experimental_recma_transforms: Some(vec![Rc::new(|program: &RecmaProgram| {
-                    program.clone()
-                })]),
-                ..Default::default()
+                experimental_recma_transforms: Some(vec![Rc::new(|program: &mut RecmaProgram| {
+                    let body = &mut program.module.body;
+                    body.push(estree::ModuleItem::Stmt(estree::Stmt::Expr(
+                        estree::ExprStmt {
+                            expr: Box::new(estree::Expr::Ident(estree::Ident::from((
+                                JsWord::from("hello"),
+                                SyntaxContext::empty(),
+                            )))),
+                            span: Span::default(),
+                        },
+                    )));
+                    Ok(())
+                })])
             }
         )?
     );
@@ -39,43 +57,14 @@ fn main() -> Result<(), String> {
     Ok(())
 }
 
-/// Visit.
-fn visit<Visitor>(node: &mdast::Node, visitor: Visitor)
-where
-    Visitor: FnMut(&mdast::Node),
-{
-    visit_impl(node, visitor);
-}
-
-/// Internal implementation to visit.
-fn visit_impl<Visitor>(node: &mdast::Node, mut visitor: Visitor) -> Visitor
-where
-    Visitor: FnMut(&mdast::Node),
-{
-    visitor(node);
-
-    if let Some(children) = node.children() {
-        let mut index = 0;
-        while index < children.len() {
-            let child = &children[index];
-            visitor = visit_impl(child, visitor);
-            index += 1;
-        }
-    }
-
-    visitor
-}
-
-/// Visit.
-fn visit_mut<Visitor>(node: &mut mdast::Node, visitor: Visitor)
+fn mdast_visit_mut<Visitor>(node: &mut mdast::Node, visitor: Visitor)
 where
     Visitor: FnMut(&mut mdast::Node),
 {
-    visit_mut_impl(node, visitor);
+    mdast_visit_mut_impl(node, visitor);
 }
 
-/// Internal implementation to visit.
-fn visit_mut_impl<Visitor>(node: &mut mdast::Node, mut visitor: Visitor) -> Visitor
+fn mdast_visit_mut_impl<Visitor>(node: &mut mdast::Node, mut visitor: Visitor) -> Visitor
 where
     Visitor: FnMut(&mut mdast::Node),
 {
@@ -85,7 +74,32 @@ where
         let mut index = 0;
         while index < children.len() {
             let child = &mut children[index];
-            visitor = visit_mut_impl(child, visitor);
+            visitor = mdast_visit_mut_impl(child, visitor);
+            index += 1;
+        }
+    }
+
+    visitor
+}
+
+fn hast_visit_mut<Visitor>(node: &mut hast::Node, visitor: Visitor)
+where
+    Visitor: FnMut(&mut hast::Node),
+{
+    hast_visit_mut_impl(node, visitor);
+}
+
+fn hast_visit_mut_impl<Visitor>(node: &mut hast::Node, mut visitor: Visitor) -> Visitor
+where
+    Visitor: FnMut(&mut hast::Node),
+{
+    visitor(node);
+
+    if let Some(children) = node.children_mut() {
+        let mut index = 0;
+        while index < children.len() {
+            let child = &mut children[index];
+            visitor = hast_visit_mut_impl(child, visitor);
             index += 1;
         }
     }

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -1,0 +1,81 @@
+extern crate mdxjs;
+
+use std::rc::Rc;
+use mdxjs::{RecmaProgram, MdastNode, HastNode, Options, PluginOptions};
+use markdown::mdast;
+
+/// Example that compiles the example MDX document from <https://mdxjs.com>
+/// to JavaScript.
+fn main() -> Result<(), String> {
+    println!(
+        "{}",
+        mdxjs::compile_with_plugins("# test", &Options {
+            ..Default::default()
+        }, &PluginOptions {
+            experimental_mdast_transforms: Some(vec![Rc::new(|root: &MdastNode| {
+                let mut root1 = root.clone();
+                visit_mut(&mut root1, |n| {
+                    match n {
+                        mdast::Node::Text(text) => {
+                            text.value = "Hello World!".into()
+                        },
+                        _ => {}
+                    };
+                });
+                root1
+            })]),
+            experimental_hast_transforms: Some(vec![Rc::new(|root: &HastNode| {
+                root.clone()
+            })]),
+            experimental_recma_transforms: Some(vec![Rc::new(|program: &RecmaProgram| {
+                program.clone()
+            })]),
+            ..Default::default()
+        })?
+    );
+
+    Ok(())
+}
+
+
+/// Visit.
+fn visit<Visitor>(node: &mdast::Node, visitor: Visitor) where Visitor: FnMut(&mdast::Node) {
+    visit_impl(node, visitor);
+}
+
+/// Internal implementation to visit.
+fn visit_impl<Visitor>(node: &mdast::Node, mut visitor: Visitor) -> Visitor where Visitor: FnMut(&mdast::Node) {
+    visitor(node);
+
+    if let Some(children) = node.children() {
+        let mut index = 0;
+        while index < children.len() {
+            let child = &children[index];
+            visitor = visit_impl(child, visitor);
+            index += 1;
+        }
+    }
+
+    visitor
+}
+
+/// Visit.
+fn visit_mut<Visitor>(node: &mut mdast::Node, visitor: Visitor) where Visitor: FnMut(&mut mdast::Node) {
+    visit_mut_impl(node, visitor);
+}
+
+/// Internal implementation to visit.
+fn visit_mut_impl<Visitor>(node: &mut mdast::Node, mut visitor: Visitor) -> Visitor where Visitor: FnMut(&mut mdast::Node) {
+    visitor(node);
+
+    if let Some(children) = node.children_mut() {
+        let mut index = 0;
+        while index < children.len() {
+            let child = &mut children[index];
+            visitor = visit_mut_impl(child, visitor);
+            index += 1;
+        }
+    }
+
+    visitor
+}

--- a/examples/plugins.rs
+++ b/examples/plugins.rs
@@ -1,50 +1,57 @@
 extern crate mdxjs;
 
-use std::rc::Rc;
-use mdxjs::{RecmaProgram, MdastNode, HastNode, Options, PluginOptions};
 use markdown::mdast;
+use mdxjs::{HastNode, MdastNode, Options, PluginOptions, RecmaProgram};
+use std::rc::Rc;
 
 /// Example that compiles the example MDX document from <https://mdxjs.com>
 /// to JavaScript.
 fn main() -> Result<(), String> {
     println!(
         "{}",
-        mdxjs::compile_with_plugins("# test", &Options {
-            ..Default::default()
-        }, &PluginOptions {
-            experimental_mdast_transforms: Some(vec![Rc::new(|root: &MdastNode| {
-                let mut root1 = root.clone();
-                visit_mut(&mut root1, |n| {
-                    match n {
-                        mdast::Node::Text(text) => {
-                            text.value = "Hello World!".into()
-                        },
-                        _ => {}
-                    };
-                });
-                root1
-            })]),
-            experimental_hast_transforms: Some(vec![Rc::new(|root: &HastNode| {
-                root.clone()
-            })]),
-            experimental_recma_transforms: Some(vec![Rc::new(|program: &RecmaProgram| {
-                program.clone()
-            })]),
-            ..Default::default()
-        })?
+        mdxjs::compile_with_plugins(
+            "# test",
+            &Options {
+                ..Default::default()
+            },
+            &PluginOptions {
+                experimental_mdast_transforms: Some(vec![Rc::new(|root: &MdastNode| {
+                    let mut root1 = root.clone();
+                    visit_mut(&mut root1, |n| {
+                        match n {
+                            mdast::Node::Text(text) => text.value = "Hello World!".into(),
+                            _ => {}
+                        };
+                    });
+                    root1
+                })]),
+                experimental_hast_transforms: Some(vec![Rc::new(|root: &HastNode| {
+                    root.clone()
+                })]),
+                experimental_recma_transforms: Some(vec![Rc::new(|program: &RecmaProgram| {
+                    program.clone()
+                })]),
+                ..Default::default()
+            }
+        )?
     );
 
     Ok(())
 }
 
-
 /// Visit.
-fn visit<Visitor>(node: &mdast::Node, visitor: Visitor) where Visitor: FnMut(&mdast::Node) {
+fn visit<Visitor>(node: &mdast::Node, visitor: Visitor)
+where
+    Visitor: FnMut(&mdast::Node),
+{
     visit_impl(node, visitor);
 }
 
 /// Internal implementation to visit.
-fn visit_impl<Visitor>(node: &mdast::Node, mut visitor: Visitor) -> Visitor where Visitor: FnMut(&mdast::Node) {
+fn visit_impl<Visitor>(node: &mdast::Node, mut visitor: Visitor) -> Visitor
+where
+    Visitor: FnMut(&mdast::Node),
+{
     visitor(node);
 
     if let Some(children) = node.children() {
@@ -60,12 +67,18 @@ fn visit_impl<Visitor>(node: &mdast::Node, mut visitor: Visitor) -> Visitor wher
 }
 
 /// Visit.
-fn visit_mut<Visitor>(node: &mut mdast::Node, visitor: Visitor) where Visitor: FnMut(&mut mdast::Node) {
+fn visit_mut<Visitor>(node: &mut mdast::Node, visitor: Visitor)
+where
+    Visitor: FnMut(&mut mdast::Node),
+{
     visit_mut_impl(node, visitor);
 }
 
 /// Internal implementation to visit.
-fn visit_mut_impl<Visitor>(node: &mut mdast::Node, mut visitor: Visitor) -> Visitor where Visitor: FnMut(&mut mdast::Node) {
+fn visit_mut_impl<Visitor>(node: &mut mdast::Node, mut visitor: Visitor) -> Visitor
+where
+    Visitor: FnMut(&mut mdast::Node),
+{
     visitor(node);
 
     if let Some(children) = node.children_mut() {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -174,7 +174,6 @@ pub struct PluginOptions {
 }
 
 impl Default for PluginOptions {
-    /// MDX with `CommonMark` defaults.
     fn default() -> Self {
         Self {
             experimental_mdast_transforms: None,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -161,9 +161,11 @@ impl MdxParseOptions {
     }
 }
 
-type MdastPlugin = Rc<dyn Fn(&MdastNode) -> MdastNode + 'static>;
-type HastPlugin = Rc<dyn Fn(&HastNode) -> HastNode + 'static>;
-type RecmaPlugin = Rc<dyn Fn(&RecmaProgram) -> RecmaProgram + 'static>;
+type MdastPlugin = Rc<dyn Fn(&mut MdastNode) -> Result<(), String> + 'static>;
+
+type HastPlugin = Rc<dyn Fn(&mut HastNode) -> Result<(), String> + 'static>;
+
+type RecmaPlugin = Rc<dyn Fn(&mut RecmaProgram) -> Result<(), String> + 'static>;
 
 pub struct PluginOptions {
     pub experimental_mdast_transforms: Option<Vec<MdastPlugin>>,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,11 +1,11 @@
 //! Configuration.
 
-use std::rc::Rc;
 use crate::mdx_plugin_recma_document::JsxRuntime;
+use std::rc::Rc;
 
-pub use markdown::mdast::Node as MdastNode;
 pub use crate::hast::Node as HastNode;
 pub use crate::hast_util_to_swc::Program as RecmaProgram;
+pub use markdown::mdast::Node as MdastNode;
 
 /// Like `Constructs` from `markdown-rs`.
 ///
@@ -161,10 +161,14 @@ impl MdxParseOptions {
     }
 }
 
+type MdastPlugin = Rc<dyn Fn(&MdastNode) -> MdastNode + 'static>;
+type HastPlugin = Rc<dyn Fn(&HastNode) -> HastNode + 'static>;
+type RecmaPlugin = Rc<dyn Fn(&RecmaProgram) -> RecmaProgram + 'static>;
+
 pub struct PluginOptions {
-    pub experimental_mdast_transforms: Option<Vec<Rc<dyn Fn(&MdastNode) -> MdastNode + 'static>>>,
-    pub experimental_hast_transforms: Option<Vec<Rc<dyn Fn(&HastNode) -> HastNode + 'static>>>,
-    pub experimental_recma_transforms: Option<Vec<Rc<dyn Fn(&RecmaProgram) -> RecmaProgram + 'static>>>,
+    pub experimental_mdast_transforms: Option<Vec<MdastPlugin>>,
+    pub experimental_hast_transforms: Option<Vec<HastPlugin>>,
+    pub experimental_recma_transforms: Option<Vec<RecmaPlugin>>,
 }
 
 impl Default for PluginOptions {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,11 @@
 //! Configuration.
 
+use std::rc::Rc;
 use crate::mdx_plugin_recma_document::JsxRuntime;
+
+pub use markdown::mdast::Node as MdastNode;
+pub use crate::hast::Node as HastNode;
+pub use crate::hast_util_to_swc::Program as RecmaProgram;
 
 /// Like `Constructs` from `markdown-rs`.
 ///
@@ -152,6 +157,23 @@ impl MdxParseOptions {
         Self {
             constructs: MdxConstructs::gfm(),
             ..Self::default()
+        }
+    }
+}
+
+pub struct PluginOptions {
+    pub experimental_mdast_transforms: Option<Vec<Rc<dyn Fn(&MdastNode) -> MdastNode + 'static>>>,
+    pub experimental_hast_transforms: Option<Vec<Rc<dyn Fn(&HastNode) -> HastNode + 'static>>>,
+    pub experimental_recma_transforms: Option<Vec<Rc<dyn Fn(&RecmaProgram) -> RecmaProgram + 'static>>>,
+}
+
+impl Default for PluginOptions {
+    /// MDX with `CommonMark` defaults.
+    fn default() -> Self {
+        Self {
+            experimental_mdast_transforms: None,
+            experimental_hast_transforms: None,
+            experimental_recma_transforms: None,
         }
     }
 }

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -43,7 +43,7 @@ use swc_core::ecma::ast::{
 pub const MAGIC_EXPLICIT_MARKER: u32 = 1337;
 
 /// Result.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program {
     /// File path.
     pub path: Option<String>,


### PR DESCRIPTION
Added an experimental plugin implementation as discussed in #5. Unfortunately I'm not very experienced in rust, so I have literally 0 idea if what I came up with is anywhere idiomatic. Maybe there is a way to avoid wrapping the plugin closures in a `std::rc::Rc`, and maybe support non static ones, but I'm not sure. Also, the plugins work by cloning the current tree and returning a modified version of it. We probably should instead modify in-place and provide a wrapper for those who prefer to clone and return.
