### PR TITLE
ci(actions): trying to create auto upgrade PR for swc_*

### DIFF
--- a/bump-swc_core.yml
+++ b/bump-swc_core.yml
@@ -1,0 +1,39 @@
+name: Bump up swc_core
+  on:
+    schedule:
+      # two times daily, at 12:00 and 06:00
+      - cron: '0 0 * * *'
+      - cron: '0 6 * * *'
+
+jobs:
+  upgrade-swc-core:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        override: true
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "gha-cargo-upgrade"
+        cache-on-failure: true
+
+    - name: Run cargo upgrade
+      uses: kwonoj/gha-cargo-upgrade@latest
+      with:
+        token: ${{ secrets.GHA_UPGRADE_TOKEN }}
+        packages: "swc_core"
+        incompatible: true


### PR DESCRIPTION
This PR trying to experiment automated action to create a PR to upgrade swc_* when a new version is released. `swc_core` is changing rapidly, and there are several pieces we need to align when we want to upgrade dependencies altogether so I hope this could reduce some of manual steps.


It is an action runs periodically (2 times a daily) which runs `cargo upgrade`, then create a PR if there's an update to be applied. If there is an open PR with a specific branch name, it won't create new but trying to update PR with new commit when there's an update.

To create fully working pull request, action requires personal access token unfortunately. I choose name `GHA_UPGRADE_TOKEN` for those, having one under repository secrets will enable action to perform: 

![image](https://user-images.githubusercontent.com/1210596/205413551-2f078a75-64c6-414a-8f42-6b33aa1c08ad.png)

We can use default `GITHUB_TOKEN` still, but it'll create PR with limited acesss with github-actions bot will not trigger any action to verify build is passing or not. (ref: https://github.com/peter-evans/create-pull-request/issues/48)

