### PR TITLE
build(cargo): bump up swc_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.4"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.44.0", features = [
+swc_core = { version = "0.43.23", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
This PR bumps up swc_core to close-to-latest to pick up some fixes.