### PR TITLE
Update `swc_core` to `v0.74.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.7"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.72.0", features = [
+swc_core = { version = "0.74.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
The swc contributor improved swc helpers, and a breaking change was required.

There's no big difference for mdxjs at the moment, but https://github.com/swc-project/swc/pull/7214 will reduce the compile time of the ES AST crate.