### PR TITLE
Update swc_core to v0.75.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.7"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.74.0", features = [
+swc_core = { version = "0.75.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
There's no breaking change in crates related to mdxjs, but we updated wasmer to v3, so we marked it as a breaking change to prevent implicit regressions