### PR TITLE
Update `swc_core` to `v0.79.x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.10"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.78.0", features = [
+swc_core = { version = "0.79.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
As documented in https://swc.rs/docs/plugin/selecting-swc-core, I needed to modify AST definition because of `await using foo = init`