### PR TITLE
Update `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.14"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.85.0", features = [
+swc_core = { version = "0.86.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
https://github.com/swc-project/swc/pull/8115 was a breaking change of

 - swc_ecma_transforms_typescript

which is **re-exported** from `swc_core`