### PR TITLE
Update `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.16"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.89.0", features = [
+swc_core = { version = "0.90.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -361,7 +361,7 @@ impl<'a> State<'a> {
                     } else {
                         // `MyComponent`
                         let prop = AssignPatProp {
-                            key: create_ident(&reference.name),
+                            key: create_ident(&reference.name).into(),
                             value: None,
                             span: DUMMY_SP,
                         };


### PR DESCRIPTION
[We refactored AST to make it less error-prone](https://github.com/swc-project/swc/pull/8532) by using a better AST design from oxc,  and it's a breaking change of AST