### PR TITLE
feat: Use a typed error to allow getting location without parsing

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,7 @@
+format_strings = true
+hex_literal_case = "Lower"
+imports_granularity = "Crate"
+reorder_impl_items = true
+use_field_init_shorthand = true
+wrap_comments = true
+edition = "2018"

--- a/examples/lib.rs
+++ b/examples/lib.rs
@@ -1,8 +1,10 @@
 extern crate mdxjs;
 
+use mdxjs::error::Error;
+
 /// Example that compiles the example MDX document from <https://mdxjs.com>
 /// to JavaScript.
-fn main() -> Result<(), String> {
+fn main() -> Result<(), Error> {
     println!(
         "{}",
         mdxjs::compile(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{borrow::Cow, fmt::Display};
 
 use markdown::unist::Point;
 
@@ -17,10 +17,24 @@ impl From<String> for Error {
     }
 }
 
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        value.to_string().into()
+    }
+}
+
+impl From<Cow<'_, str>> for Error {
+    fn from(value: Cow<str>) -> Self {
+        value.into_owned().into()
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(point) = &self.point {
             write!(f, "{}:{} ", point.line, point.column)?;
+        } else {
+            write!(f, "0:0 ")?;
         }
 
         write!(f, "{}", self.msg)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,16 @@
+use markdown::unist::Point;
+
+#[derive(Debug)]
+pub struct Error {
+    pub msg: String,
+    pub point: Option<Point>,
+}
+
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        Self {
+            msg: value,
+            point: None,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use markdown::unist::Point;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Error {
     pub msg: String,
     pub point: Option<Point>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,9 +32,9 @@ impl From<Cow<'_, str>> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(point) = &self.point {
-            write!(f, "{}:{} ", point.line, point.column)?;
+            write!(f, "{}:{}: ", point.line, point.column)?;
         } else {
-            write!(f, "0:0 ")?;
+            write!(f, "0:0: ")?;
         }
 
         write!(f, "{}", self.msg)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use markdown::unist::Point;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -12,5 +14,15 @@ impl From<String> for Error {
             msg: value,
             point: None,
         }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(point) = &self.point {
+            write!(f, "{}:{} ", point.line, point.column)?;
+        }
+
+        write!(f, "{}", self.msg)
     }
 }

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -1285,7 +1285,8 @@ mod tests {
                 }),
                 None,
                 None
-            ),
+            )
+            .map_err(|err| err.to_string()),
             Err(
                 "0:0: Unexpected extra content in spread (such as `{...x,y}`): only a single \
                  spread is supported (such as `{...x}`)"

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -1244,7 +1244,8 @@ mod tests {
                 }),
                 None,
                 None
-            ),
+            )
+            .map_err(|err| err.to_string()),
             Err("0:0: Could not parse expression with swc: Unexpected eof".into()),
             "should support an `MdxElement` (element, attribute w/ broken expression value)",
         );
@@ -1412,7 +1413,8 @@ mod tests {
                 }),
                 None,
                 None
-            ),
+            )
+            .map_err(|err| err.to_string()),
             Err(
                 "0:0: Could not parse esm with swc: Expected 'from', got 'numeric literal (1, 1)'"
                     .into()

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -26,11 +26,13 @@
 //! TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 //! SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use crate::hast;
-use crate::swc::{parse_esm_to_tree, parse_expression_to_tree};
-use crate::swc_utils::{
-    create_jsx_attr_name_from_str, create_jsx_name_from_str, inter_element_whitespace,
-    position_to_span,
+use crate::{
+    hast,
+    swc::{parse_esm_to_tree, parse_expression_to_tree},
+    swc_utils::{
+        create_jsx_attr_name_from_str, create_jsx_name_from_str, inter_element_whitespace,
+        position_to_span,
+    },
 };
 use core::str;
 use markdown::{Location, MdxExpressionKind};
@@ -667,10 +669,12 @@ const PROP_TO_ATTR_EXCEPTIONS_SHARED: [(&str, &str); 48] = [
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hast;
-    use crate::hast_util_to_swc::{hast_util_to_swc, Program};
-    use crate::markdown::mdast;
-    use crate::swc::serialize;
+    use crate::{
+        hast,
+        hast_util_to_swc::{hast_util_to_swc, Program},
+        markdown::mdast,
+        swc::serialize,
+    };
     use pretty_assertions::assert_eq;
     use swc_core::ecma::ast::{
         Ident, ImportDecl, ImportDefaultSpecifier, ImportPhase, ImportSpecifier, JSXAttrName,
@@ -678,7 +682,7 @@ mod tests {
     };
 
     #[test]
-    fn comments() -> Result<(), String> {
+    fn comments() -> Result<(), Error> {
         let mut comment_ast = hast_util_to_swc(
             &hast::Node::Comment(hast::Comment {
                 value: "a".into(),
@@ -734,7 +738,7 @@ mod tests {
     }
 
     #[test]
-    fn elements() -> Result<(), String> {
+    fn elements() -> Result<(), Error> {
         let mut element_ast = hast_util_to_swc(
             &hast::Node::Element(hast::Element {
                 tag_name: "a".into(),
@@ -844,7 +848,7 @@ mod tests {
     }
 
     #[test]
-    fn element_attributes() -> Result<(), String> {
+    fn element_attributes() -> Result<(), Error> {
         assert_eq!(
             serialize(
                 &mut hast_util_to_swc(
@@ -976,7 +980,7 @@ mod tests {
     }
 
     #[test]
-    fn mdx_element() -> Result<(), String> {
+    fn mdx_element() -> Result<(), Error> {
         let mut mdx_element_ast = hast_util_to_swc(
             &hast::Node::MdxJsxElement(hast::MdxJsxElement {
                 name: None,
@@ -1064,7 +1068,7 @@ mod tests {
     }
 
     #[test]
-    fn mdx_element_name() -> Result<(), String> {
+    fn mdx_element_name() -> Result<(), Error> {
         assert_eq!(
             serialize(
                 &mut hast_util_to_swc(
@@ -1126,7 +1130,7 @@ mod tests {
     }
 
     #[test]
-    fn mdx_element_attributes() -> Result<(), String> {
+    fn mdx_element_attributes() -> Result<(), Error> {
         assert_eq!(
             serialize(
                 &mut hast_util_to_swc(
@@ -1269,14 +1273,21 @@ mod tests {
             hast_util_to_swc(
                 &hast::Node::MdxJsxElement(hast::MdxJsxElement {
                     name: Some("a".into()),
-                    attributes: vec![hast::AttributeContent::Expression { value: "...b,c".into(), stops: vec![] } ],
+                    attributes: vec![hast::AttributeContent::Expression {
+                        value: "...b,c".into(),
+                        stops: vec![]
+                    }],
                     children: vec![],
                     position: None,
                 }),
                 None,
                 None
             ),
-            Err("0:0: Unexpected extra content in spread (such as `{...x,y}`): only a single spread is supported (such as `{...x}`)".into()),
+            Err(
+                "0:0: Unexpected extra content in spread (such as `{...x,y}`): only a single \
+                 spread is supported (such as `{...x}`)"
+                    .into()
+            ),
             "should support an `MdxElement` (element, broken expression attribute)",
         );
 
@@ -1284,7 +1295,7 @@ mod tests {
     }
 
     #[test]
-    fn mdx_expression() -> Result<(), String> {
+    fn mdx_expression() -> Result<(), Error> {
         let mut mdx_expression_ast = hast_util_to_swc(
             &hast::Node::MdxExpression(hast::MdxExpression {
                 value: "a".into(),
@@ -1341,7 +1352,7 @@ mod tests {
     }
 
     #[test]
-    fn mdx_esm() -> Result<(), String> {
+    fn mdx_esm() -> Result<(), Error> {
         let mut mdxjs_esm_ast = hast_util_to_swc(
             &hast::Node::MdxjsEsm(hast::MdxjsEsm {
                 value: "import a from 'b'".into(),
@@ -1411,7 +1422,7 @@ mod tests {
     }
 
     #[test]
-    fn root() -> Result<(), String> {
+    fn root() -> Result<(), Error> {
         let mut root_ast = hast_util_to_swc(
             &hast::Node::Root(hast::Root {
                 children: vec![hast::Node::Text(hast::Text {
@@ -1467,7 +1478,7 @@ mod tests {
     }
 
     #[test]
-    fn text() -> Result<(), String> {
+    fn text() -> Result<(), Error> {
         let mut text_ast = hast_util_to_swc(
             &hast::Node::Text(hast::Text {
                 value: "a".into(),
@@ -1520,7 +1531,7 @@ mod tests {
     }
 
     #[test]
-    fn text_empty() -> Result<(), String> {
+    fn text_empty() -> Result<(), Error> {
         let text_ast = hast_util_to_swc(
             &hast::Node::Text(hast::Text {
                 value: String::new(),
@@ -1548,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn doctype() -> Result<(), String> {
+    fn doctype() -> Result<(), Error> {
         let mut doctype_ast = hast_util_to_swc(
             &hast::Node::Doctype(hast::Doctype { position: None }),
             None,

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -670,6 +670,7 @@ const PROP_TO_ATTR_EXCEPTIONS_SHARED: [(&str, &str); 48] = [
 mod tests {
     use super::*;
     use crate::{
+        error::Error,
         hast,
         hast_util_to_swc::{hast_util_to_swc, Program},
         markdown::mdast,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use crate::{
 ///
 /// ```
 /// use mdxjs::compile;
-/// # fn main() -> Result<(), String> {
+/// # fn main() -> Result<(), Error> {
 ///
 /// assert_eq!(compile("# Hi!", &Default::default())?, "import { jsx as _jsx } from \"react/jsx-runtime\";\nfunction _createMdxContent(props) {\n    const _components = Object.assign({\n        h1: \"h1\"\n    }, props.components);\n    return _jsx(_components.h1, {\n        children: \"Hi!\"\n    });\n}\nfunction MDXContent(props = {}) {\n    const { wrapper: MDXLayout } = props.components || {};\n    return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {\n        children: _jsx(_createMdxContent, props)\n    })) : _createMdxContent(props);\n}\nexport default MDXContent;\n");
 /// # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub use crate::{
 /// ## Examples
 ///
 /// ```
+/// # use mdxjs::Error;
 /// use mdxjs::compile;
 /// # fn main() -> Result<(), Error> {
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,7 @@
 //!
 //! This module exposes primarily [`compile()`][].
 //!
-//! *   [`compile()`][]
-//!     — turn MDX into JavaScript
+//! * [`compile()`][] — turn MDX into JavaScript
 #![deny(clippy::pedantic)]
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::too_many_lines)]
@@ -13,6 +12,7 @@
 
 extern crate markdown;
 mod configuration;
+pub mod error;
 mod hast;
 mod hast_util_to_swc;
 mod mdast_util_to_hast;
@@ -23,6 +23,7 @@ mod swc_util_build_jsx;
 mod swc_utils;
 
 use crate::{
+    error::Error,
     hast_util_to_swc::hast_util_to_swc,
     mdast_util_to_hast::mdast_util_to_hast,
     mdx_plugin_recma_document::{mdx_plugin_recma_document, Options as DocumentOptions},
@@ -32,8 +33,10 @@ use crate::{
 };
 use markdown::{to_mdast, Constructs, Location, ParseOptions};
 
-pub use crate::configuration::{MdxConstructs, MdxParseOptions, Options};
-pub use crate::mdx_plugin_recma_document::JsxRuntime;
+pub use crate::{
+    configuration::{MdxConstructs, MdxParseOptions, Options},
+    mdx_plugin_recma_document::JsxRuntime,
+};
 
 /// Turn MDX into JavaScript.
 ///
@@ -52,7 +55,7 @@ pub use crate::mdx_plugin_recma_document::JsxRuntime;
 ///
 /// This project errors for many different reasons, such as syntax errors in
 /// the MDX format or misconfiguration.
-pub fn compile(value: &str, options: &Options) -> Result<String, String> {
+pub fn compile(value: &str, options: &Options) -> Result<String, Error> {
     let parse_options = ParseOptions {
         constructs: Constructs {
             attention: options.parse.constructs.attention,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::{
 /// ## Examples
 ///
 /// ```
-/// # use mdxjs::Error;
+/// # use mdxjs::error::Error;
 /// use mdxjs::compile;
 /// # fn main() -> Result<(), Error> {
 ///

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -4,6 +4,7 @@
 //! by the same author.
 
 use crate::{
+    error::Error,
     hast_util_to_swc::Program,
     swc_utils::{
         bytepos_to_point, create_call_expression, create_ident, create_ident_expression,

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -825,7 +825,8 @@ export default MDXContent;
         assert_eq!(
             compile("export default a = 1\n\nexport default b = 2")
                 .err()
-                .unwrap(),
+                .unwrap()
+                .to_string(),
             "3:1: Cannot specify multiple layouts (previous: 1:1-1:21)",
             "should crash on multiple layouts"
         );
@@ -863,7 +864,8 @@ export default MDXContent;
                 None
             )
             .err()
-            .unwrap(),
+            .unwrap()
+            .to_string(),
             "0:0: Cannot use TypeScript interface declarations as default export in MDX files. \
              The default export is reserved for a layout, which must be a component",
             "should crash on a TypeScript default interface declaration"

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -1010,6 +1010,7 @@ fn is_props_receiving_fn(name: &Option<String>) -> bool {
 mod tests {
     use super::*;
     use crate::{
+        error::Error,
         hast_util_to_swc::hast_util_to_swc,
         mdast_util_to_hast::mdast_util_to_hast,
         mdx_plugin_recma_document::{mdx_plugin_recma_document, Options as DocumentOptions},

--- a/src/swc.rs
+++ b/src/swc.rs
@@ -200,7 +200,7 @@ pub fn parse_expression_to_tree(
     kind: &MdxExpressionKind,
     stops: &[Stop],
     location: Option<&Location>,
-) -> Result<Option<Box<Expr>>, String> {
+) -> Result<Option<Box<Expr>>, Error> {
     let result = parse_expression_core(value, kind);
     let mut rewrite_context = RewriteStopsContext { stops, location };
 

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -213,7 +213,7 @@ impl<'a> State<'a> {
     fn jsx_children_to_expressions(
         &mut self,
         mut children: Vec<JSXElementChild>,
-    ) -> Result<Vec<Expr>, String> {
+    ) -> Result<Vec<Expr>, Error> {
         let mut result = vec![];
         children.reverse();
         while let Some(child) = children.pop() {

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -791,6 +791,7 @@ fn jsx_text_to_value(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::{
+        error::Error,
         hast_util_to_swc::Program,
         swc::{flat_comments, serialize},
     };

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -1,6 +1,7 @@
 //! Turn JSX into function calls.
 
 use crate::{
+    error::Error,
     hast_util_to_swc::Program,
     mdx_plugin_recma_document::JsxRuntime,
     swc_utils::{

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -156,7 +156,7 @@ struct State<'a> {
     /// Location info.
     location: Option<&'a Location>,
     /// Whether walking the tree produced an error.
-    error: Option<String>,
+    error: Option<Error>,
     /// Path to file.
     filepath: Option<String>,
     /// Whether the user is in development mode.

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -1381,7 +1381,8 @@ _jsx(\"a\", {
         assert_eq!(
             swc_util_build_jsx(&mut program, &Options::default(), None)
                 .err()
-                .unwrap(),
+                .unwrap()
+                .to_string(),
             "0:0: Unexpected spread child, which is not supported in Babel, SWC, or React",
             "should not support a spread child"
         );
@@ -1514,7 +1515,8 @@ _jsx(\"a\", {
         assert_eq!(
             compile("<a {...b} key='c' />", &Options::default())
                 .err()
-                .unwrap(),
+                .unwrap()
+                .to_string(),
             "1:11: Expected `key` to come before any spread expressions",
             "should crash on a key after a spread in the automatic runtime"
         );

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -184,7 +184,7 @@ impl<'a> State<'a> {
     fn jsx_attribute_value_to_expression(
         &mut self,
         value: Option<JSXAttrValue>,
-    ) -> Result<Expr, String> {
+    ) -> Result<Expr, Error> {
         match value {
             // Boolean prop.
             None => Ok(create_bool_expression(true)),
@@ -256,7 +256,7 @@ impl<'a> State<'a> {
         &mut self,
         attributes: Option<Vec<JSXAttrOrSpread>>,
         children: Option<Vec<Expr>>,
-    ) -> Result<(Option<Expr>, Option<Expr>), String> {
+    ) -> Result<(Option<Expr>, Option<Expr>), Error> {
         let mut objects = vec![];
         let mut fields = vec![];
         let mut spread = false;
@@ -382,7 +382,7 @@ impl<'a> State<'a> {
         name: Expr,
         attributes: Option<Vec<JSXAttrOrSpread>>,
         mut children: Vec<Expr>,
-    ) -> Result<Expr, String> {
+    ) -> Result<Expr, Error> {
         let (callee, parameters) = if self.automatic {
             let is_static_children = children.len() > 1;
             let (props, key) = self.jsx_attributes_to_expressions(attributes, Some(children))?;
@@ -556,7 +556,7 @@ impl<'a> State<'a> {
     }
 
     /// Turn a JSX element into an expression.
-    fn jsx_element_to_expression(&mut self, element: JSXElement) -> Result<Expr, String> {
+    fn jsx_element_to_expression(&mut self, element: JSXElement) -> Result<Expr, Error> {
         let children = self.jsx_children_to_expressions(element.children)?;
         let mut name = jsx_element_name_to_expression(element.opening.name);
 
@@ -573,7 +573,7 @@ impl<'a> State<'a> {
     }
 
     /// Turn a JSX fragment into an expression.
-    fn jsx_fragment_to_expression(&mut self, fragment: JSXFragment) -> Result<Expr, String> {
+    fn jsx_fragment_to_expression(&mut self, fragment: JSXFragment) -> Result<Expr, Error> {
         let name = if self.automatic {
             self.import_fragment = true;
             create_ident_expression("_Fragment")
@@ -621,7 +621,7 @@ impl<'a> VisitMut for State<'a> {
 fn find_directives(
     comments: &Vec<Comment>,
     location: Option<&Location>,
-) -> Result<Directives, String> {
+) -> Result<Directives, Error> {
     let mut directives = Directives::default();
 
     for comment in comments {
@@ -903,7 +903,8 @@ mod tests {
                 &Options::default()
             )
             .err()
-            .unwrap(),
+            .unwrap()
+            .to_string(),
             "1:1: Runtime must be either `automatic` or `classic`, not unknown",
             "should crash on a non-automatic, non-classic `@jsxRuntime` directive"
         );

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -8,13 +8,19 @@ use markdown::{
     Location,
 };
 
-use swc_core::common::{BytePos, Span, SyntaxContext, DUMMY_SP};
-use swc_core::ecma::ast::{
-    BinExpr, BinaryOp, Bool, CallExpr, Callee, ComputedPropName, Expr, ExprOrSpread, Ident,
-    JSXAttrName, JSXElementName, JSXMemberExpr, JSXNamespacedName, JSXObject, Lit, MemberExpr,
-    MemberProp, Null, Number, ObjectLit, PropName, PropOrSpread, Str,
+use swc_core::{
+    common::{BytePos, Span, SyntaxContext, DUMMY_SP},
+    ecma::{
+        ast::{
+            BinExpr, BinaryOp, Bool, CallExpr, Callee, ComputedPropName, Expr, ExprOrSpread, Ident,
+            JSXAttrName, JSXElementName, JSXMemberExpr, JSXNamespacedName, JSXObject, Lit,
+            MemberExpr, MemberProp, Null, Number, ObjectLit, PropName, PropOrSpread, Str,
+        },
+        visit::{noop_visit_mut_type, VisitMut},
+    },
 };
-use swc_core::ecma::visit::{noop_visit_mut_type, VisitMut};
+
+use crate::error::Error;
 
 /// Turn a unist position, into an SWC span, of two byte positions.
 ///
@@ -78,8 +84,11 @@ pub fn bytepos_to_point(bytepos: BytePos, location: Option<&Location>) -> Option
 }
 
 /// Prefix an error message with an optional point.
-pub fn prefix_error_with_point(reason: &str, point: Option<&Point>) -> String {
-    format!("{}: {}", point_opt_to_string(point), reason)
+pub fn prefix_error_with_point(reason: &str, point: Option<&Point>) -> Error {
+    Error {
+        msg: reason.to_string(),
+        point: point.cloned(),
+    }
 }
 
 /// Serialize a unist position for humans.
@@ -630,7 +639,7 @@ pub fn inter_element_whitespace(value: &str) -> bool {
 
     while index < bytes.len() {
         match bytes[index] {
-            b'\t' | 0x0C | b'\r' | b'\n' | b' ' => {}
+            b'\t' | 0x0c | b'\r' | b'\n' | b' ' => {}
             _ => return false,
         }
         index += 1;

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -665,7 +665,7 @@ mod tests {
     #[test]
     fn prefix_error_with_point_test() {
         assert_eq!(
-            prefix_error_with_point("aaa", None),
+            prefix_error_with_point("aaa", None).to_string(),
             "0:0: aaa",
             "should support no point"
         );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,7 +3,7 @@ use mdxjs::{compile, JsxRuntime, Options};
 use pretty_assertions::assert_eq;
 
 #[test]
-fn simple() -> Result<(), String> {
+fn simple() -> Result<(), Error> {
     assert_eq!(
         compile("", &Options::default())?,
         "import { Fragment as _Fragment, jsx as _jsx } from \"react/jsx-runtime\";
@@ -25,13 +25,16 @@ export default MDXContent;
 }
 
 #[test]
-fn development() -> Result<(), String> {
+fn development() -> Result<(), Error> {
     assert_eq!(
-        compile("<A />", &Options {
-            development: true,
-            filepath: Some("example.mdx".into()),
-            ..Default::default()
-        })?,
+        compile(
+            "<A />",
+            &Options {
+                development: true,
+                filepath: Some("example.mdx".into()),
+                ..Default::default()
+            }
+        )?,
         "import { jsxDEV as _jsxDEV } from \"react/jsx-dev-runtime\";
 function _createMdxContent(props) {
     const { A } = props.components || {};
@@ -54,7 +57,9 @@ function MDXContent(props = {}) {
 }
 export default MDXContent;
 function _missingMdxReference(id, component, place) {
-    throw new Error(\"Expected \" + (component ? \"component\" : \"object\") + \" `\" + id + \"` to be defined: you likely forgot to import, pass, or provide it.\" + (place ? \"\\nIt’s referenced in your code at `\" + place + \"` in `example.mdx`\" : \"\"));
+    throw new Error(\"Expected \" + (component ? \"component\" : \"object\") + \" `\" + id + \"` \
+         to be defined: you likely forgot to import, pass, or provide it.\" + (place ? \"\\nIt’s \
+         referenced in your code at `\" + place + \"` in `example.mdx`\" : \"\"));
 }
 ",
         "should support `options.development: true`",
@@ -64,12 +69,15 @@ function _missingMdxReference(id, component, place) {
 }
 
 #[test]
-fn provider() -> Result<(), String> {
+fn provider() -> Result<(), Error> {
     assert_eq!(
-        compile("<A />",  &Options {
-            provider_import_source: Some("@mdx-js/react".into()),
-            ..Default::default()
-        })?,
+        compile(
+            "<A />",
+            &Options {
+                provider_import_source: Some("@mdx-js/react".into()),
+                ..Default::default()
+            }
+        )?,
         "import { jsx as _jsx } from \"react/jsx-runtime\";
 import { useMDXComponents as _provideComponents } from \"@mdx-js/react\";
 function _createMdxContent(props) {
@@ -85,7 +93,8 @@ function MDXContent(props = {}) {
 }
 export default MDXContent;
 function _missingMdxReference(id, component) {
-    throw new Error(\"Expected \" + (component ? \"component\" : \"object\") + \" `\" + id + \"` to be defined: you likely forgot to import, pass, or provide it.\");
+    throw new Error(\"Expected \" + (component ? \"component\" : \"object\") + \" `\" + id + \"` \
+         to be defined: you likely forgot to import, pass, or provide it.\");
 }
 ",
         "should support `options.provider_import_source`",
@@ -95,18 +104,22 @@ function _missingMdxReference(id, component) {
 }
 
 #[test]
-fn jsx() -> Result<(), String> {
+fn jsx() -> Result<(), Error> {
     assert_eq!(
-        compile("", &Options {
-            jsx: true,
-            ..Default::default()
-        })?,
+        compile(
+            "",
+            &Options {
+                jsx: true,
+                ..Default::default()
+            }
+        )?,
         "function _createMdxContent(props) {
     return <></>;
 }
 function MDXContent(props = {}) {
     const { wrapper: MDXLayout } = props.components || {};
-    return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props}/></MDXLayout> : _createMdxContent(props);
+    return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props}/></MDXLayout> : \
+         _createMdxContent(props);
 }
 export default MDXContent;
 ",
@@ -117,19 +130,23 @@ export default MDXContent;
 }
 
 #[test]
-fn classic() -> Result<(), String> {
+fn classic() -> Result<(), Error> {
     assert_eq!(
-        compile("", &Options {
-            jsx_runtime: Some(JsxRuntime::Classic),
-            ..Default::default()
-        })?,
+        compile(
+            "",
+            &Options {
+                jsx_runtime: Some(JsxRuntime::Classic),
+                ..Default::default()
+            }
+        )?,
         "import React from \"react\";
 function _createMdxContent(props) {
     return React.createElement(React.Fragment);
 }
 function MDXContent(props = {}) {
     const { wrapper: MDXLayout } = props.components || {};
-    return MDXLayout ? React.createElement(MDXLayout, props, React.createElement(_createMdxContent, props)) : _createMdxContent(props);
+    return MDXLayout ? React.createElement(MDXLayout, props, \
+         React.createElement(_createMdxContent, props)) : _createMdxContent(props);
 }
 export default MDXContent;
 ",
@@ -140,7 +157,7 @@ export default MDXContent;
 }
 
 #[test]
-fn import_source() -> Result<(), String> {
+fn import_source() -> Result<(), Error> {
     assert_eq!(
         compile(
             "",
@@ -168,22 +185,26 @@ export default MDXContent;
 }
 
 #[test]
-fn pragmas() -> Result<(), String> {
+fn pragmas() -> Result<(), Error> {
     assert_eq!(
-        compile("", &Options {
-            jsx_runtime: Some(JsxRuntime::Classic),
-            pragma: Some("a.b".into()),
-            pragma_frag: Some("a.c".into()),
-            pragma_import_source: Some("d".into()),
-            ..Default::default()
-        })?,
+        compile(
+            "",
+            &Options {
+                jsx_runtime: Some(JsxRuntime::Classic),
+                pragma: Some("a.b".into()),
+                pragma_frag: Some("a.c".into()),
+                pragma_import_source: Some("d".into()),
+                ..Default::default()
+            }
+        )?,
         "import a from \"d\";
 function _createMdxContent(props) {
     return a.b(a.c);
 }
 function MDXContent(props = {}) {
     const { wrapper: MDXLayout } = props.components || {};
-    return MDXLayout ? a.b(MDXLayout, props, a.b(_createMdxContent, props)) : _createMdxContent(props);
+    return MDXLayout ? a.b(MDXLayout, props, a.b(_createMdxContent, props)) : \
+         _createMdxContent(props);
 }
 export default MDXContent;
 ",
@@ -194,7 +215,7 @@ export default MDXContent;
 }
 
 #[test]
-fn unravel_elements() -> Result<(), String> {
+fn unravel_elements() -> Result<(), Error> {
     assert_eq!(
         compile(
             "<x>a</x>
@@ -239,7 +260,7 @@ export default MDXContent;
 }
 
 #[test]
-fn unravel_expressions() -> Result<(), String> {
+fn unravel_expressions() -> Result<(), Error> {
     assert_eq!(
         compile("{1} {2}", &Default::default())?,
         "import { Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs } from \"react/jsx-runtime\";
@@ -269,7 +290,7 @@ export default MDXContent;
 }
 
 #[test]
-fn explicit_jsx() -> Result<(), String> {
+fn explicit_jsx() -> Result<(), Error> {
     assert_eq!(
         compile(
             "<h1>asd</h1>
@@ -350,7 +371,11 @@ fn err_expression_broken_multiline_comment_c() {
 fn err_expression_broken_line_comment_a() {
     assert_eq!(
         compile("{x//}", &Default::default()),
-        Err("1:6: Could not parse expression with swc: Unexpected unclosed line comment, expected line ending: `\\n`".into()),
+        Err(
+            "1:6: Could not parse expression with swc: Unexpected unclosed line comment, expected \
+             line ending: `\\n`"
+                .into()
+        ),
         "should crash on an unclosed line comment after an expression",
     );
 }
@@ -454,7 +479,11 @@ fn err_expression_value_extra_comment() {
 fn err_expression_spread_none() {
     assert_eq!(
         compile("<a {x} />", &Default::default()),
-        Err("1:5: Unexpected prop in spread (such as `{x}`): only a spread is supported (such as `{...x}`)".into()),
+        Err(
+            "1:5: Unexpected prop in spread (such as `{x}`): only a spread is supported (such as \
+             `{...x}`)"
+                .into()
+        ),
         "should crash on a non-spread",
     );
 }
@@ -472,7 +501,11 @@ fn err_expression_spread_multi_1() {
 fn err_expression_spread_multi_2() {
     assert_eq!(
         compile("<a {...x, y} />", &Default::default()),
-        Err("1:5: Unexpected extra content in spread (such as `{...x,y}`): only a single spread is supported (such as `{...x}`)".into()),
+        Err(
+            "1:5: Unexpected extra content in spread (such as `{...x,y}`): only a single spread \
+             is supported (such as `{...x}`)"
+                .into()
+        ),
         "should crash on more content after a (spread) expression (2)",
     );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
 extern crate mdxjs;
-use mdxjs::{compile, JsxRuntime, Options};
+use mdxjs::{compile, error::Error, JsxRuntime, Options};
 use pretty_assertions::assert_eq;
 
 #[test]


### PR DESCRIPTION
I added an error type, which consists of the error message and optional source location.

This would be enough for most users, including usage in next.js/turbopack - providing good error message with some underline to the source code.