### PR TITLE
Update `swc_core` to `v0.91.x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.17"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.90.0", features = [
+swc_core = { version = "0.91.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
We added support for abstract auto-accessors.

Related: https://github.com/swc-project/swc/pull/8736