### PR TITLE
Update `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.17"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.91.0", features = [
+swc_core = { version = "0.92.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
I made a breaking change in `swc_ecma_minifier` because an **exposed** configuration struct was wrongly typed. (bool => Option<bool> to support _optional_ default).

https://github.com/swc-project/swc/pull/8925

As `swc_core` reexports the minifier, it was also a breaking change of `swc_core`.