### PR TITLE
Update `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.17"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.95.0", features = [
+swc_core = { version = "0.96.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -327,7 +327,7 @@ fn err_expression_broken_multiline_comment_a() {
             .err()
             .unwrap()
             .to_string(),
-        "1:6: Could not parse expression with swc: Unexpected eof (mdxjs-rs:swc)",
+        "1:6: Could not parse expression with swc: Unterminated block comment (mdxjs-rs:swc)",
         "should crash on an unclosed block comment after an expression",
     );
 }
@@ -339,7 +339,7 @@ fn err_expression_broken_multiline_comment_b() {
             .err()
             .unwrap()
             .to_string(),
-        "1:6: Could not parse expression with swc: Unterminated block comment (mdxjs-rs:swc)",
+        "1:2: Could not parse expression with swc: Unexpected eof (mdxjs-rs:swc)",
         "should crash on an unclosed block comment in an empty expression",
     );
 }


### PR DESCRIPTION
A breaking change was inevitable because we upgraded `browserslist` and it had a breaking change.

 - https://github.com/swc-project/swc/pull/9023