### PR TITLE
Update `swc_core` to `v0.100.x `

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.18"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.96.0", features = [
+swc_core = { version = "0.99.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.18"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.99.0", features = [
+swc_core = { version = "0.100.0", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -34,13 +34,13 @@ use crate::swc_utils::{
 };
 use core::str;
 use markdown::{Location, MdxExpressionKind};
+use swc_core::alloc::collections::FxHashSet;
+use swc_core::common::Span;
 use swc_core::ecma::ast::{
     Expr, ExprStmt, JSXAttr, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,
     JSXElement, JSXElementChild, JSXEmptyExpr, JSXExpr, JSXExprContainer, JSXFragment,
     JSXOpeningElement, JSXOpeningFragment, Lit, Module, ModuleItem, SpreadElement, Stmt, Str,
 };
-
-pub const MAGIC_EXPLICIT_MARKER: u32 = 1337;
 
 /// Result.
 #[derive(Debug, PartialEq, Eq)]
@@ -82,6 +82,7 @@ pub fn hast_util_to_swc(
     tree: &hast::Node,
     path: Option<String>,
     location: Option<&Location>,
+    explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Program, markdown::message::Message> {
     let mut context = Context {
         space: Space::Html,
@@ -89,7 +90,7 @@ pub fn hast_util_to_swc(
         esm: vec![],
         location,
     };
-    let expr = match one(&mut context, tree)? {
+    let expr = match one(&mut context, tree, explicit_jsxs)? {
         Some(JSXElementChild::JSXFragment(x)) => Some(Expr::JSXFragment(x)),
         Some(JSXElementChild::JSXElement(x)) => Some(Expr::JSXElement(x)),
         Some(child) => Some(Expr::JSXFragment(create_fragment(vec![child], tree))),
@@ -122,14 +123,15 @@ pub fn hast_util_to_swc(
 fn one(
     context: &mut Context,
     node: &hast::Node,
+    explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Option<JSXElementChild>, markdown::message::Message> {
     let value = match node {
         hast::Node::Comment(x) => Some(transform_comment(context, node, x)),
-        hast::Node::Element(x) => transform_element(context, node, x)?,
-        hast::Node::MdxJsxElement(x) => transform_mdx_jsx_element(context, node, x)?,
+        hast::Node::Element(x) => transform_element(context, node, x, explicit_jsxs)?,
+        hast::Node::MdxJsxElement(x) => transform_mdx_jsx_element(context, node, x, explicit_jsxs)?,
         hast::Node::MdxExpression(x) => transform_mdx_expression(context, node, x)?,
         hast::Node::MdxjsEsm(x) => transform_mdxjs_esm(context, node, x)?,
-        hast::Node::Root(x) => transform_root(context, node, x)?,
+        hast::Node::Root(x) => transform_root(context, node, x, explicit_jsxs)?,
         hast::Node::Text(x) => transform_text(context, node, x),
         // Ignore:
         hast::Node::Doctype(_) => None,
@@ -141,6 +143,7 @@ fn one(
 fn all(
     context: &mut Context,
     parent: &hast::Node,
+    explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Vec<JSXElementChild>, markdown::message::Message> {
     let mut result = vec![];
     if let Some(children) = parent.children() {
@@ -149,7 +152,7 @@ fn all(
             let child = &children[index];
             // To do: remove line endings between table elements?
             // <https://github.com/syntax-tree/hast-util-to-estree/blob/6c45f166d106ea3a165c14ec50c35ed190055e65/lib/index.js>
-            if let Some(child) = one(context, child)? {
+            if let Some(child) = one(context, child, explicit_jsxs)? {
                 result.push(child);
             }
             index += 1;
@@ -188,6 +191,7 @@ fn transform_element(
     context: &mut Context,
     node: &hast::Node,
     element: &hast::Element,
+    explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Option<JSXElementChild>, markdown::message::Message> {
     let space = context.space;
 
@@ -195,7 +199,7 @@ fn transform_element(
         context.space = Space::Svg;
     }
 
-    let children = all(context, node)?;
+    let children = all(context, node, explicit_jsxs)?;
 
     context.space = space;
 
@@ -252,7 +256,6 @@ fn transform_element(
         attrs,
         children,
         node,
-        false,
     )))))
 }
 
@@ -261,6 +264,7 @@ fn transform_mdx_jsx_element(
     context: &mut Context,
     node: &hast::Node,
     element: &hast::MdxJsxElement,
+    explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Option<JSXElementChild>, markdown::message::Message> {
     let space = context.space;
 
@@ -270,7 +274,7 @@ fn transform_mdx_jsx_element(
         }
     }
 
-    let children = all(context, node)?;
+    let children = all(context, node, explicit_jsxs)?;
 
     context.space = space;
 
@@ -330,7 +334,8 @@ fn transform_mdx_jsx_element(
     }
 
     Ok(Some(if let Some(name) = &element.name {
-        JSXElementChild::JSXElement(Box::new(create_element(name, attrs, children, node, true)))
+        explicit_jsxs.insert(position_to_span(node.position()));
+        JSXElementChild::JSXElement(Box::new(create_element(name, attrs, children, node)))
     } else {
         JSXElementChild::JSXFragment(create_fragment(children, node))
     }))
@@ -377,8 +382,9 @@ fn transform_root(
     context: &mut Context,
     node: &hast::Node,
     _root: &hast::Root,
+    explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Option<JSXElementChild>, markdown::message::Message> {
-    let mut children = all(context, node)?;
+    let mut children = all(context, node, explicit_jsxs)?;
     let mut queue = vec![];
     let mut nodes = vec![];
     let mut seen = false;
@@ -445,15 +451,8 @@ fn create_element(
     attrs: Vec<JSXAttrOrSpread>,
     children: Vec<JSXElementChild>,
     node: &hast::Node,
-    explicit: bool,
 ) -> JSXElement {
-    let mut span = position_to_span(node.position());
-
-    span.ctxt = if explicit {
-        swc_core::common::SyntaxContext::from_u32(MAGIC_EXPLICIT_MARKER)
-    } else {
-        swc_core::common::SyntaxContext::empty()
-    };
+    let span = position_to_span(node.position());
 
     JSXElement {
         opening: JSXOpeningElement {
@@ -686,6 +685,8 @@ mod tests {
 
     #[test]
     fn comments() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut comment_ast = hast_util_to_swc(
             &hast::Node::Comment(hast::Comment {
                 value: "a".into(),
@@ -693,6 +694,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -742,6 +744,8 @@ mod tests {
 
     #[test]
     fn elements() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut element_ast = hast_util_to_swc(
             &hast::Node::Element(hast::Element {
                 tag_name: "a".into(),
@@ -754,6 +758,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -819,10 +824,11 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs,
                 )?
                 .module,
-                None
+                None,
             ),
             "<a>{\"a\"}</a>;\n",
             "should support an `Element` w/ children",
@@ -838,7 +844,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs,
                 )?
                 .module,
                 None
@@ -852,6 +859,8 @@ mod tests {
 
     #[test]
     fn element_attributes() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         assert_eq!(
             serialize(
                 &mut hast_util_to_swc(
@@ -862,7 +871,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs,
                 )?
                 .module,
                 None
@@ -881,7 +891,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs,
                 )?
                 .module,
                 None
@@ -900,7 +911,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs,
                 )?
                 .module,
                 None
@@ -922,7 +934,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -947,7 +960,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -970,7 +984,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -984,6 +999,8 @@ mod tests {
 
     #[test]
     fn mdx_element() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut mdx_element_ast = hast_util_to_swc(
             &hast::Node::MdxJsxElement(hast::MdxJsxElement {
                 name: None,
@@ -993,6 +1010,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -1037,7 +1055,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1058,7 +1077,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1072,6 +1092,8 @@ mod tests {
 
     #[test]
     fn mdx_element_name() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         assert_eq!(
             serialize(
                 &mut hast_util_to_swc(
@@ -1082,7 +1104,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1101,7 +1124,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1120,7 +1144,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1134,6 +1159,8 @@ mod tests {
 
     #[test]
     fn mdx_element_attributes() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         assert_eq!(
             serialize(
                 &mut hast_util_to_swc(
@@ -1147,7 +1174,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1169,7 +1197,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1191,7 +1220,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1218,7 +1248,8 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
                 None
@@ -1244,7 +1275,8 @@ mod tests {
                     position: None,
                 }),
                 None,
-                None
+                None,
+                &mut explicit_jsxs
             )
             .err()
             .unwrap()
@@ -1266,10 +1298,11 @@ mod tests {
                         position: None,
                     }),
                     None,
-                    None
+                    None,
+                    &mut explicit_jsxs
                 )?
                 .module,
-                None
+                None,
             ),
             "<a {...b}/>;\n",
             "should support an `MdxElement` (element, expression attribute)",
@@ -1284,7 +1317,8 @@ mod tests {
                     position: None,
                 }),
                 None,
-                None
+                None,
+                &mut explicit_jsxs
             ).err().unwrap().to_string(),
             "Unexpected extra content in spread (such as `{...x,y}`): only a single spread is supported (such as `{...x}`) (mdxjs-rs:swc)",
             "should support an `MdxElement` (element, broken expression attribute)",
@@ -1295,6 +1329,8 @@ mod tests {
 
     #[test]
     fn mdx_expression() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut mdx_expression_ast = hast_util_to_swc(
             &hast::Node::MdxExpression(hast::MdxExpression {
                 value: "a".into(),
@@ -1303,6 +1339,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -1353,6 +1390,8 @@ mod tests {
 
     #[test]
     fn mdx_esm() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut mdxjs_esm_ast = hast_util_to_swc(
             &hast::Node::MdxjsEsm(hast::MdxjsEsm {
                 value: "import a from 'b'".into(),
@@ -1361,6 +1400,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -1410,7 +1450,8 @@ mod tests {
                     stops: vec![],
                 }),
                 None,
-                None
+                None,
+                &mut explicit_jsxs
             )
             .err()
             .unwrap()
@@ -1424,6 +1465,8 @@ mod tests {
 
     #[test]
     fn root() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut root_ast = hast_util_to_swc(
             &hast::Node::Root(hast::Root {
                 children: vec![hast::Node::Text(hast::Text {
@@ -1434,6 +1477,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -1480,6 +1524,8 @@ mod tests {
 
     #[test]
     fn text() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut text_ast = hast_util_to_swc(
             &hast::Node::Text(hast::Text {
                 value: "a".into(),
@@ -1487,6 +1533,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -1533,6 +1580,8 @@ mod tests {
 
     #[test]
     fn text_empty() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let text_ast = hast_util_to_swc(
             &hast::Node::Text(hast::Text {
                 value: String::new(),
@@ -1540,6 +1589,7 @@ mod tests {
             }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(
@@ -1561,10 +1611,13 @@ mod tests {
 
     #[test]
     fn doctype() -> Result<(), markdown::message::Message> {
+        let mut explicit_jsxs = FxHashSet::default();
+
         let mut doctype_ast = hast_util_to_swc(
             &hast::Node::Doctype(hast::Doctype { position: None }),
             None,
             None,
+            &mut explicit_jsxs,
         )?;
 
         assert_eq!(

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -678,9 +678,10 @@ mod tests {
     use crate::markdown::mdast;
     use crate::swc::serialize;
     use pretty_assertions::assert_eq;
+    use swc_core::common::SyntaxContext;
     use swc_core::ecma::ast::{
-        Ident, ImportDecl, ImportDefaultSpecifier, ImportPhase, ImportSpecifier, JSXAttrName,
-        JSXElementName, ModuleDecl,
+        Ident, IdentName, ImportDecl, ImportDefaultSpecifier, ImportPhase, ImportSpecifier,
+        JSXAttrName, JSXElementName, ModuleDecl,
     };
 
     #[test]
@@ -768,12 +769,12 @@ mod tests {
                                     span: swc_core::common::DUMMY_SP,
                                     sym: "a".into(),
                                     optional: false,
+                                    ctxt: SyntaxContext::empty()
                                 }),
                                 attrs: vec![JSXAttrOrSpread::JSXAttr(JSXAttr {
-                                    name: JSXAttrName::Ident(Ident {
+                                    name: JSXAttrName::Ident(IdentName {
                                         sym: "className".into(),
                                         span: swc_core::common::DUMMY_SP,
-                                        optional: false,
                                     }),
                                     value: Some(JSXAttrValue::Lit(Lit::Str(Str {
                                         value: "b".into(),
@@ -1323,6 +1324,7 @@ mod tests {
                                     sym: "a".into(),
                                     span: swc_core::common::DUMMY_SP,
                                     optional: false,
+                                    ctxt: SyntaxContext::empty()
                                 }))),
                                 span: swc_core::common::DUMMY_SP,
                             },)],
@@ -1373,6 +1375,7 @@ mod tests {
                                 sym: "a".into(),
                                 optional: false,
                                 span: swc_core::common::DUMMY_SP,
+                                ctxt: SyntaxContext::empty()
                             },
                             span: swc_core::common::DUMMY_SP,
                         })],

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -191,7 +191,7 @@ pub fn mdx_plugin_recma_document(
                     bytepos_to_point(decl.span.lo, location).as_ref(),
                 )?;
                 layout = true;
-                layout_position = span_to_position(&decl.span, location);
+                layout_position = span_to_position(decl.span, location);
                 match decl.decl {
                     DefaultDecl::Class(cls) => {
                         replacements.push(create_layout_decl(Expr::Class(cls)));
@@ -218,7 +218,7 @@ pub fn mdx_plugin_recma_document(
                     bytepos_to_point(expr.span.lo, location).as_ref(),
                 )?;
                 layout = true;
-                layout_position = span_to_position(&expr.span, location);
+                layout_position = span_to_position(expr.span, location);
                 replacements.push(create_layout_decl(*expr.expr));
             }
             // ```js
@@ -249,7 +249,7 @@ pub fn mdx_plugin_recma_document(
                                         bytepos_to_point(ident.span.lo, location).as_ref(),
                                     )?;
                                     layout = true;
-                                    layout_position = span_to_position(&ident.span, location);
+                                    layout_position = span_to_position(ident.span, location);
                                     take = true;
                                     id = Some(ident.clone());
                                 }
@@ -569,6 +569,7 @@ mod tests {
     use crate::swc_utils::create_bool_expression;
     use markdown::{to_mdast, ParseOptions};
     use pretty_assertions::assert_eq;
+    use swc_core::alloc::collections::FxHashSet;
     use swc_core::ecma::ast::{
         EmptyStmt, ExportDefaultDecl, ExprStmt, JSXClosingFragment, JSXFragment,
         JSXOpeningFragment, JSXText, Module, TsInterfaceBody, TsInterfaceDecl, WhileStmt,
@@ -585,7 +586,8 @@ mod tests {
             },
         )?;
         let hast = mdast_util_to_hast(&mdast);
-        let mut program = hast_util_to_swc(&hast, None, Some(&location))?;
+        let mut program =
+            hast_util_to_swc(&hast, None, Some(&location), &mut FxHashSet::default())?;
         mdx_plugin_recma_document(&mut program, &DocumentOptions::default(), Some(&location))?;
         Ok(serialize(&mut program.module, Some(&program.comments)))
     }

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -13,6 +13,7 @@ use markdown::{
     unist::{Point, Position},
     Location,
 };
+use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{
     AssignPat, BindingIdent, BlockStmt, Callee, CondExpr, Decl, DefaultDecl, ExportDefaultExpr,
     ExportSpecifier, Expr, ExprOrSpread, FnDecl, Function, ImportDecl, ImportDefaultSpecifier,
@@ -462,12 +463,14 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                     span: swc_core::common::DUMMY_SP,
                 })],
                 span: swc_core::common::DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
             span: swc_core::common::DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
         }),
     })));
 
@@ -499,12 +502,14 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                     span: swc_core::common::DUMMY_SP,
                 })],
                 span: swc_core::common::DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
             span: swc_core::common::DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
         }),
     })));
 
@@ -529,6 +534,7 @@ fn create_layout_decl(expr: Expr) -> ModuleItem {
             definite: false,
         }],
         span: swc_core::common::DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
     }))))
 }
 

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -150,7 +150,7 @@ pub fn mdx_plugin_recma_document(
 
         replacements.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
             specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
-                local: create_ident(sym),
+                local: create_ident(sym).into(),
                 span: swc_core::common::DUMMY_SP,
             })],
             src: Box::new(create_str(
@@ -279,7 +279,7 @@ pub fn mdx_plugin_recma_document(
                     if let Some(source) = source {
                         replacements.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
                             specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-                                local: create_ident("MDXLayout"),
+                                local: create_ident("MDXLayout").into(),
                                 imported: Some(ModuleExportName::Ident(id)),
                                 span: swc_core::common::DUMMY_SP,
                                 is_type_only: false,
@@ -387,7 +387,7 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
     // ```
     let mut result = Expr::JSXElement(Box::new(JSXElement {
         opening: JSXOpeningElement {
-            name: JSXElementName::Ident(create_ident("MDXLayout")),
+            name: JSXElementName::Ident(create_ident("MDXLayout").into()),
             attrs: vec![JSXAttrOrSpread::SpreadElement(SpreadElement {
                 dot3_token: swc_core::common::DUMMY_SP,
                 expr: Box::new(create_ident_expression("props")),
@@ -397,7 +397,7 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
             span: swc_core::common::DUMMY_SP,
         },
         closing: Some(JSXClosingElement {
-            name: JSXElementName::Ident(create_ident("MDXLayout")),
+            name: JSXElementName::Ident(create_ident("MDXLayout").into()),
             span: swc_core::common::DUMMY_SP,
         }),
         // ```jsx
@@ -405,7 +405,7 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
         // ```
         children: vec![JSXElementChild::JSXElement(Box::new(JSXElement {
             opening: JSXOpeningElement {
-                name: JSXElementName::Ident(create_ident("_createMdxContent")),
+                name: JSXElementName::Ident(create_ident("_createMdxContent").into()),
                 attrs: vec![JSXAttrOrSpread::SpreadElement(SpreadElement {
                     dot3_token: swc_core::common::DUMMY_SP,
                     expr: Box::new(create_ident_expression("props")),
@@ -445,12 +445,12 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
     // }
     // ```
     let create_mdx_content = ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
-        ident: create_ident("_createMdxContent"),
+        ident: create_ident("_createMdxContent").into(),
         declare: false,
         function: Box::new(Function {
             params: vec![Param {
                 pat: Pat::Ident(BindingIdent {
-                    id: create_ident("props"),
+                    id: create_ident("props").into(),
                     type_ann: None,
                 }),
                 decorators: vec![],
@@ -480,13 +480,13 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
     // }
     // ```
     let mdx_content = ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
-        ident: create_ident("MDXContent"),
+        ident: create_ident("MDXContent").into(),
         declare: false,
         function: Box::new(Function {
             params: vec![Param {
                 pat: Pat::Assign(AssignPat {
                     left: Box::new(Pat::Ident(BindingIdent {
-                        id: create_ident("props"),
+                        id: create_ident("props").into(),
                         type_ann: None,
                     })),
                     right: Box::new(create_object_expression(vec![])),
@@ -526,7 +526,7 @@ fn create_layout_decl(expr: Expr) -> ModuleItem {
         declare: false,
         decls: vec![VarDeclarator {
             name: Pat::Ident(BindingIdent {
-                id: create_ident("MDXLayout"),
+                id: create_ident("MDXLayout").into(),
                 type_ann: None,
             }),
             init: Some(Box::new(expr)),
@@ -843,7 +843,7 @@ export default MDXContent;
                                     decl: DefaultDecl::TsInterfaceDecl(Box::new(
                                         TsInterfaceDecl {
                                             span: swc_core::common::DUMMY_SP,
-                                            id: create_ident("a"),
+                                            id: create_ident("a").into(),
                                             declare: true,
                                             type_params: None,
                                             extends: vec![],
@@ -998,14 +998,14 @@ export default MDXContent;
                     expr: Box::new(Expr::JSXElement(Box::new(JSXElement {
                         span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningElement {
-                            name: JSXElementName::Ident(create_ident("a")),
+                            name: JSXElementName::Ident(create_ident("a").into()),
                             attrs: vec![],
                             self_closing: false,
                             type_args: None,
                             span: swc_core::common::DUMMY_SP,
                         },
                         closing: Some(JSXClosingElement {
-                            name: JSXElementName::Ident(create_ident("a")),
+                            name: JSXElementName::Ident(create_ident("a").into()),
                             span: swc_core::common::DUMMY_SP,
                         }),
                         children: vec![JSXElementChild::JSXText(JSXText {

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -865,8 +865,10 @@ impl<'a> VisitMut for State<'a> {
 fn create_import_provider(source: &str) -> ModuleItem {
     ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
         specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
-            local: create_ident("_provideComponents"),
-            imported: Some(ModuleExportName::Ident(create_ident("useMDXComponents"))),
+            local: create_ident("_provideComponents").into(),
+            imported: Some(ModuleExportName::Ident(
+                create_ident("useMDXComponents").into(),
+            )),
             span: DUMMY_SP,
             is_type_only: false,
         })],
@@ -889,7 +891,7 @@ fn create_error_helper(development: bool, path: Option<String>) -> ModuleItem {
     let mut parameters = vec![
         Param {
             pat: Pat::Ident(BindingIdent {
-                id: create_ident("id"),
+                id: create_ident("id").into(),
                 type_ann: None,
             }),
             decorators: vec![],
@@ -897,7 +899,7 @@ fn create_error_helper(development: bool, path: Option<String>) -> ModuleItem {
         },
         Param {
             pat: Pat::Ident(BindingIdent {
-                id: create_ident("component"),
+                id: create_ident("component").into(),
                 type_ann: None,
             }),
             decorators: vec![],
@@ -909,7 +911,7 @@ fn create_error_helper(development: bool, path: Option<String>) -> ModuleItem {
     if development {
         parameters.push(Param {
             pat: Pat::Ident(BindingIdent {
-                id: create_ident("place"),
+                id: create_ident("place").into(),
                 type_ann: None,
             }),
             decorators: vec![],
@@ -959,7 +961,7 @@ fn create_error_helper(development: bool, path: Option<String>) -> ModuleItem {
     }
 
     ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
-        ident: create_ident("_missingMdxReference"),
+        ident: create_ident("_missingMdxReference").into(),
         declare: false,
         function: Box::new(Function {
             params: parameters,
@@ -974,16 +976,19 @@ fn create_error_helper(development: bool, path: Option<String>) -> ModuleItem {
                         }]),
                         span: DUMMY_SP,
                         type_args: None,
+                        ctxt: SyntaxContext::empty(),
                     })),
                     span: DUMMY_SP,
                 })],
                 span: DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
             span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
         }),
     })))
 }
@@ -1829,7 +1834,7 @@ function _missingMdxReference(id, component, place) {
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
                         name: Pat::Ident(BindingIdent {
-                            id: create_ident("a"),
+                            id: create_ident("a").into(),
                             type_ann: None,
                         }),
                         init: Some(Box::new(Expr::JSXElement(Box::new(JSXElement {
@@ -1847,6 +1852,7 @@ function _missingMdxReference(id, component, place) {
                         definite: false,
                     }],
                     span: DUMMY_SP,
+                    ctxt: SyntaxContext::empty(),
                     declare: false,
                 }))))],
             },
@@ -1877,6 +1883,7 @@ function _missingMdxReference(id, component, place) {
                     }],
                     span: DUMMY_SP,
                     declare: false,
+                    ctxt: SyntaxContext::empty(),
                 }))))],
             },
         };
@@ -1900,12 +1907,13 @@ function _missingMdxReference(id, component, place) {
                     kind: VarDeclKind::Let,
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
-                        name: Pat::Expr(Box::new(Expr::Ident(create_ident("a")))),
+                        name: Pat::Expr(Box::new(Expr::Ident(create_ident("a").into()))),
                         init: None,
                         definite: false,
                     }],
                     span: DUMMY_SP,
                     declare: false,
+                    ctxt: SyntaxContext::empty(),
                 }))))],
             },
         };

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -482,6 +482,7 @@ impl<'a> State<'a> {
                                 span: DUMMY_SP,
                             })],
                             span: DUMMY_SP,
+                            ctxt: SyntaxContext::empty(),
                         };
                         arr.body = Box::new(BlockStmtOrExpr::BlockStmt(block));
                     }

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -12,6 +12,7 @@ use crate::swc_utils::{
     jsx_member_to_parts, position_to_string, span_to_position,
 };
 use markdown::{unist::Position, Location};
+use swc_core::common::SyntaxContext;
 use swc_core::common::{util::take::Take, Span, DUMMY_SP};
 use swc_core::ecma::ast::{
     ArrowExpr, AssignPatProp, BinaryOp, BindingIdent, BlockStmt, BlockStmtOrExpr, Callee,
@@ -292,7 +293,7 @@ impl<'a> State<'a> {
                 let declarator = VarDeclarator {
                     span: DUMMY_SP,
                     name: Pat::Ident(BindingIdent {
-                        id: create_ident("_components"),
+                        id: create_ident("_components").into(),
                         type_ann: None,
                     }),
                     init: Some(Box::new(components_init)),
@@ -316,7 +317,7 @@ impl<'a> State<'a> {
                     let declarator = VarDeclarator {
                         span: DUMMY_SP,
                         name: Pat::Ident(BindingIdent {
-                            id: create_ident(&alias.safe),
+                            id: create_ident(&alias.safe).into(),
                             type_ann: None,
                         }),
                         init: Some(Box::new(Expr::Member(create_member(
@@ -350,7 +351,7 @@ impl<'a> State<'a> {
                     // `wrapper: MDXLayout`
                     if reference.name == "MDXLayout" {
                         let binding = BindingIdent {
-                            id: create_ident(&reference.name),
+                            id: create_ident(&reference.name).into(),
                             type_ann: None,
                         };
                         let prop = KeyValuePatProp {
@@ -392,6 +393,7 @@ impl<'a> State<'a> {
                 decls: declarators,
                 span: DUMMY_SP,
                 declare: false,
+                ctxt: SyntaxContext::empty(),
             };
             let var_decl = Decl::Var(Box::new(decl));
             statements.push(Stmt::Decl(var_decl));

--- a/src/swc.rs
+++ b/src/swc.rs
@@ -7,7 +7,7 @@ use markdown::{mdast::Stop, Location, MdxExpressionKind, MdxSignal};
 use std::rc::Rc;
 use swc_core::common::{
     comments::{Comment, Comments, SingleThreadedComments, SingleThreadedCommentsMap},
-    source_map::Pos,
+    source_map::SmallPos,
     sync::Lrc,
     BytePos, FileName, FilePathMapping, SourceFile, SourceMap, Span, Spanned,
 };
@@ -354,7 +354,7 @@ fn create_config(source: String) -> (SourceFile, Syntax, EsVersion) {
     (
         // File.
         SourceFile::new(
-            FileName::Anon,
+            FileName::Anon.into(),
             false,
             FileName::Anon,
             source,

--- a/src/swc.rs
+++ b/src/swc.rs
@@ -356,7 +356,7 @@ fn create_config(source: String) -> (SourceFile, Syntax, EsVersion) {
         SourceFile::new(
             FileName::Anon.into(),
             false,
-            FileName::Anon,
+            FileName::Anon.into(),
             source,
             BytePos::from_usize(1),
         ),

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -71,8 +71,8 @@ pub fn swc_util_build_jsx(
 
     if state.import_fragment {
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
-            local: create_ident("_Fragment"),
-            imported: Some(ModuleExportName::Ident(create_ident("Fragment"))),
+            local: create_ident("_Fragment").into(),
+            imported: Some(ModuleExportName::Ident(create_ident("Fragment").into())),
             span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
@@ -80,8 +80,8 @@ pub fn swc_util_build_jsx(
 
     if state.import_jsx {
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
-            local: create_ident("_jsx"),
-            imported: Some(ModuleExportName::Ident(create_ident("jsx"))),
+            local: create_ident("_jsx").into(),
+            imported: Some(ModuleExportName::Ident(create_ident("jsx").into())),
             span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
@@ -89,8 +89,8 @@ pub fn swc_util_build_jsx(
 
     if state.import_jsxs {
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
-            local: create_ident("_jsxs"),
-            imported: Some(ModuleExportName::Ident(create_ident("jsxs"))),
+            local: create_ident("_jsxs").into(),
+            imported: Some(ModuleExportName::Ident(create_ident("jsxs").into())),
             span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
@@ -98,7 +98,7 @@ pub fn swc_util_build_jsx(
 
     if state.import_jsx_dev {
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
-            local: create_ident("_jsxDEV"),
+            local: create_ident("_jsxDEV").into(),
             imported: Some(ModuleExportName::Ident(create_ident("jsxDEV"))),
             span: swc_core::common::DUMMY_SP,
             is_type_only: false,
@@ -1357,14 +1357,14 @@ _jsx(\"a\", {
                     expr: Box::new(Expr::JSXElement(Box::new(JSXElement {
                         span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningElement {
-                            name: JSXElementName::Ident(create_ident("a")),
+                            name: JSXElementName::Ident(create_ident("a").into()),
                             attrs: vec![],
                             self_closing: false,
                             type_args: None,
                             span: swc_core::common::DUMMY_SP,
                         },
                         closing: Some(JSXClosingElement {
-                            name: JSXElementName::Ident(create_ident("a")),
+                            name: JSXElementName::Ident(create_ident("a").into()),
                             span: swc_core::common::DUMMY_SP,
                         }),
                         children: vec![JSXElementChild::JSXSpreadChild(JSXSpreadChild {

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -11,6 +11,7 @@ use crate::swc_utils::{
 };
 use core::str;
 use markdown::{message::Message, Location};
+use swc_core::common::SyntaxContext;
 use swc_core::common::{
     comments::{Comment, CommentKind},
     util::take::Take,
@@ -99,7 +100,7 @@ pub fn swc_util_build_jsx(
     if state.import_jsx_dev {
         specifiers.push(ImportSpecifier::Named(ImportNamedSpecifier {
             local: create_ident("_jsxDEV").into(),
-            imported: Some(ModuleExportName::Ident(create_ident("jsxDEV"))),
+            imported: Some(ModuleExportName::Ident(create_ident("jsxDEV").into())),
             span: swc_core::common::DUMMY_SP,
             is_type_only: false,
         }));
@@ -547,6 +548,7 @@ impl<'a> State<'a> {
             args: parameters,
             type_args: None,
             span: *span,
+            ctxt: SyntaxContext::empty(),
         };
 
         Ok(Expr::Call(call_expression))
@@ -801,7 +803,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use swc_core::common::Spanned;
     use swc_core::common::{
-        comments::SingleThreadedComments, source_map::Pos, BytePos, FileName, SourceFile,
+        comments::SingleThreadedComments, source_map::SmallPos, BytePos, FileName, SourceFile,
     };
     use swc_core::ecma::ast::{
         EsVersion, ExprStmt, JSXClosingElement, JSXElementName, JSXOpeningElement, JSXSpreadChild,
@@ -815,9 +817,9 @@ mod tests {
         let comments = SingleThreadedComments::default();
         let result = parse_file_as_module(
             &SourceFile::new(
-                FileName::Anon,
+                FileName::Anon.into(),
                 false,
-                FileName::Anon,
+                FileName::Anon.into(),
                 value.into(),
                 BytePos::from_usize(1),
             ),
@@ -1569,7 +1571,7 @@ _jsxDEV(_Fragment, {
                     expr: Box::new(Expr::JSXElement(Box::new(JSXElement {
                         span: swc_core::common::DUMMY_SP,
                         opening: JSXOpeningElement {
-                            name: JSXElementName::Ident(create_ident("a")),
+                            name: JSXElementName::Ident(create_ident("a").into()),
                             attrs: vec![],
                             self_closing: true,
                             type_args: None,

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -376,7 +376,7 @@ impl<'a> State<'a> {
     /// Turn the parsed parts from fragments or elements into a call.
     fn jsx_expressions_to_call(
         &mut self,
-        span: &swc_core::common::Span,
+        span: swc_core::common::Span,
         name: Expr,
         attributes: Option<Vec<JSXAttrOrSpread>>,
         mut children: Vec<Expr>,
@@ -547,7 +547,7 @@ impl<'a> State<'a> {
             callee: Callee::Expr(Box::new(callee)),
             args: parameters,
             type_args: None,
-            span: *span,
+            span,
             ctxt: SyntaxContext::empty(),
         };
 
@@ -571,7 +571,7 @@ impl<'a> State<'a> {
             }
         }
 
-        self.jsx_expressions_to_call(&element.span, name, Some(element.opening.attrs), children)
+        self.jsx_expressions_to_call(element.span, name, Some(element.opening.attrs), children)
     }
 
     /// Turn a JSX fragment into an expression.
@@ -586,7 +586,7 @@ impl<'a> State<'a> {
             self.fragment_expression.clone()
         };
         let children = self.jsx_children_to_expressions(fragment.children)?;
-        self.jsx_expressions_to_call(&fragment.span, name, None, children)
+        self.jsx_expressions_to_call(fragment.span, name, None, children)
     }
 }
 

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -36,7 +36,7 @@ pub fn position_to_span(position: Option<&Position>) -> Span {
 ///
 /// > 👉 **Note**: SWC byte positions are offset by one: they are `0` when they
 /// > are missing or incremented by `1` when valid.
-pub fn span_to_position(span: &Span, location: Option<&Location>) -> Option<Position> {
+pub fn span_to_position(span: Span, location: Option<&Location>) -> Option<Position> {
     let lo = span.lo.0 as usize;
     let hi = span.hi.0 as usize;
 

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -380,16 +380,17 @@ pub fn create_member_prop_from_str(name: &str) -> MemberProp {
 pub fn create_jsx_name_from_str(name: &str) -> JSXElementName {
     match parse_jsx_name(name) {
         // `a`
-        JsxName::Normal(name) => JSXElementName::Ident(create_ident(name)),
+        JsxName::Normal(name) => JSXElementName::Ident(create_ident(name).into()),
         // `a:b`
         JsxName::Namespace(ns, name) => JSXElementName::JSXNamespacedName(JSXNamespacedName {
+            span: DUMMY_SP,
             ns: create_ident(ns),
             name: create_ident(name),
         }),
         // `a.b.c`
         JsxName::Member(parts) => {
             let mut member = create_jsx_member(
-                JSXObject::Ident(create_ident(parts[0])),
+                JSXObject::Ident(create_ident(parts[0]).into()),
                 create_ident(parts[1]),
             );
             let mut index = 2;
@@ -407,7 +408,11 @@ pub fn create_jsx_name_from_str(name: &str) -> JSXElementName {
 
 /// Generate a member expression from an object and prop.
 pub fn create_jsx_member(obj: JSXObject, prop: IdentName) -> JSXMemberExpr {
-    JSXMemberExpr { obj, prop }
+    JSXMemberExpr {
+        span: DUMMY_SP,
+        obj,
+        prop,
+    }
 }
 
 /// Turn an JSX element name into an expression.
@@ -432,6 +437,7 @@ pub fn create_jsx_attr_name_from_str(name: &str) -> JSXAttrName {
         }
         // `<a b:c />`
         JsxName::Namespace(ns, name) => JSXAttrName::JSXNamespacedName(JSXNamespacedName {
+            span: DUMMY_SP,
             ns: create_ident(ns),
             name: create_ident(name),
         }),
@@ -449,11 +455,10 @@ pub fn jsx_member_expression_to_expression(node: JSXMemberExpr) -> Expr {
 }
 
 /// Turn an ident into a member prop.
-pub fn ident_to_member_prop(node: &Ident) -> MemberProp {
+pub fn ident_to_member_prop(node: &IdentName) -> MemberProp {
     if is_identifier_name(node.as_ref()) {
-        MemberProp::Ident(Ident {
+        MemberProp::Ident(IdentName {
             sym: node.sym.clone(),
-            optional: false,
             span: node.span,
         })
     } else {
@@ -655,7 +660,7 @@ mod tests {
             jsx_member_to_parts(&JSXMemberExpr {
                 span: DUMMY_SP,
                 prop: create_ident("a"),
-                obj: JSXObject::Ident(create_ident("b"))
+                obj: JSXObject::Ident(create_ident("b").into())
             }),
             vec!["b", "a"],
             "should support a member with 2 items"

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -8,13 +8,16 @@ use markdown::{
     Location,
 };
 
-use swc_core::common::{BytePos, Span, SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::{
     BinExpr, BinaryOp, Bool, CallExpr, Callee, ComputedPropName, Expr, ExprOrSpread, Ident,
     JSXAttrName, JSXElementName, JSXMemberExpr, JSXNamespacedName, JSXObject, Lit, MemberExpr,
     MemberProp, Null, Number, ObjectLit, PropName, PropOrSpread, Str,
 };
 use swc_core::ecma::visit::{noop_visit_mut_type, VisitMut};
+use swc_core::{
+    common::{BytePos, Span, SyntaxContext, DUMMY_SP},
+    ecma::ast::IdentName,
+};
 
 /// Turn a unist position, into an SWC span, of two byte positions.
 ///
@@ -186,10 +189,9 @@ pub fn create_span(lo: u32, hi: u32) -> Span {
 /// ```js
 /// a
 /// ```
-pub fn create_ident(sym: &str) -> Ident {
-    Ident {
+pub fn create_ident(sym: &str) -> IdentName {
+    IdentName {
         sym: sym.into(),
-        optional: false,
         span: DUMMY_SP,
     }
 }
@@ -405,7 +407,7 @@ pub fn create_jsx_name_from_str(name: &str) -> JSXElementName {
 }
 
 /// Generate a member expression from an object and prop.
-pub fn create_jsx_member(obj: JSXObject, prop: Ident) -> JSXMemberExpr {
+pub fn create_jsx_member(obj: JSXObject, prop: IdentName) -> JSXMemberExpr {
     JSXMemberExpr { obj, prop }
 }
 

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -202,7 +202,7 @@ pub fn create_ident(sym: &str) -> IdentName {
 /// a
 /// ```
 pub fn create_ident_expression(sym: &str) -> Expr {
-    Expr::Ident(create_ident(sym))
+    Expr::Ident(create_ident(sym).into())
 }
 
 /// Generate a null.
@@ -654,6 +654,7 @@ mod tests {
     fn jsx_member_to_parts_test() {
         assert_eq!(
             jsx_member_to_parts(&JSXMemberExpr {
+                span: DUMMY_SP,
                 prop: create_ident("a"),
                 obj: JSXObject::Ident(create_ident("b"))
             }),
@@ -663,12 +664,15 @@ mod tests {
 
         assert_eq!(
             jsx_member_to_parts(&JSXMemberExpr {
+                span: DUMMY_SP,
                 prop: create_ident("a"),
                 obj: JSXObject::JSXMemberExpr(Box::new(JSXMemberExpr {
+                    span: DUMMY_SP,
                     prop: create_ident("b"),
                     obj: JSXObject::JSXMemberExpr(Box::new(JSXMemberExpr {
+                        span: DUMMY_SP,
                         prop: create_ident("c"),
-                        obj: JSXObject::Ident(create_ident("d"))
+                        obj: JSXObject::Ident(create_ident("d").into())
                     }))
                 }))
             }),

--- a/src/swc_utils.rs
+++ b/src/swc_utils.rs
@@ -27,7 +27,6 @@ pub fn position_to_span(position: Option<&Position>) -> Span {
     position.map_or(DUMMY_SP, |d| Span {
         lo: point_to_bytepos(&d.start),
         hi: point_to_bytepos(&d.end),
-        ctxt: SyntaxContext::empty(),
     })
 }
 
@@ -180,7 +179,6 @@ pub fn create_span(lo: u32, hi: u32) -> Span {
     Span {
         lo: BytePos(lo),
         hi: BytePos(hi),
-        ctxt: SyntaxContext::default(),
     }
 }
 
@@ -287,6 +285,7 @@ pub fn create_call(callee: Callee, args: Vec<ExprOrSpread>) -> CallExpr {
         args,
         span: DUMMY_SP,
         type_args: None,
+        ctxt: SyntaxContext::empty(),
     }
 }
 


### PR DESCRIPTION
https://swc.rs/docs/plugin/selecting-swc-core

I found that mdxjs-rs was using a hack based on `SyntaxContext`, but it's not possible anymore and I'm not sure how should I fix it.