### PR TITLE
feat: ✨ upgrade swc to 0.99.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,13 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.18"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.96.0", features = [
+swc_core = { version = "0.99.6", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",
   "ecma_parser",
   "common",
+  "ecma_utils",
 ] }
 
 [dev-dependencies]

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -13,6 +13,7 @@ use markdown::{
     unist::{Point, Position},
     Location,
 };
+use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{
     AssignPat, BindingIdent, BlockStmt, Callee, CondExpr, Decl, DefaultDecl, ExportDefaultExpr,
     ExportSpecifier, Expr, ExprOrSpread, FnDecl, Function, ImportDecl, ImportDefaultSpecifier,
@@ -462,12 +463,14 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                     span: swc_core::common::DUMMY_SP,
                 })],
                 span: swc_core::common::DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
             span: swc_core::common::DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
         }),
     })));
 
@@ -499,12 +502,14 @@ fn create_mdx_content(expr: Option<Expr>, has_internal_layout: bool) -> Vec<Modu
                     span: swc_core::common::DUMMY_SP,
                 })],
                 span: swc_core::common::DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
             }),
             is_generator: false,
             is_async: false,
             type_params: None,
             return_type: None,
             span: swc_core::common::DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
         }),
     })));
 
@@ -529,6 +534,7 @@ fn create_layout_decl(expr: Expr) -> ModuleItem {
             definite: false,
         }],
         span: swc_core::common::DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
     }))))
 }
 
@@ -634,8 +640,8 @@ function MDXContent(props = {}) {
 }
 export default MDXContent;
 ",
-        "should support an export all",
-    );
+            "should support an export all",
+        );
 
         assert_eq!(
             compile("export function a() {}")?,

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -1125,7 +1125,7 @@ export default MDXContent;
             compile(
                 "export {MyLayout as default} from './a.js'\n\n# hi",
                 &Options::default(),
-                true,
+                true
             )?,
             "import { MyLayout as MDXLayout } from './a.js';
 function _createMdxContent(props) {
@@ -1261,7 +1261,7 @@ export default MDXContent;
         assert_eq!(
             compile(
                 "import * as X from './a.js'\n\n<X />",
-                &Options::default(), true,
+                &Options::default(), true
             )?,
             "import * as X from './a.js';
 function _createMdxContent(props) {
@@ -1289,8 +1289,8 @@ export default MDXContent;
 
 <A />
 ",
-                &Options::default(), true,
-            )?,
+            &Options::default(), true
+        )?,
             "export function A() {
     return <B/>;
 }
@@ -1317,8 +1317,8 @@ export default MDXContent;
 
 <A />
 ",
-                &Options::default(), true,
-            )?,
+            &Options::default(), true
+        )?,
             "export class A {
 }
 function _createMdxContent(props) {
@@ -1344,7 +1344,7 @@ export default MDXContent;
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 function _createMdxContent(props) {
@@ -1377,7 +1377,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 function _createMdxContent(props) {
@@ -1408,7 +1408,7 @@ export default MDXContent;
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export function A() {
@@ -1450,7 +1450,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export function X(x) {
@@ -1535,7 +1535,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export function A() {
@@ -1603,7 +1603,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 function _createMdxContent(props) {
@@ -1645,7 +1645,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export function A() {
@@ -1682,7 +1682,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export const A = ()=>{
@@ -1716,7 +1716,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export const A = function B() {
@@ -1755,7 +1755,7 @@ function _missingMdxReference(id, component) {
                 &Options {
                     provider_import_source: Some("x".into()),
                     ..Options::default()
-                }, true,
+                }, true
             )?,
             "import { useMDXComponents as _provideComponents } from \"x\";
 export function A() {

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -4,10 +4,10 @@ use crate::hast_util_to_swc::Program;
 use crate::mdx_plugin_recma_document::JsxRuntime;
 use crate::swc_utils::{
     bytepos_to_point, create_bool_expression, create_call_expression, create_ident,
-    create_ident_expression, create_member_expression_from_str, create_null_expression,
-    create_num_expression, create_object_expression, create_prop_name, create_str,
-    create_str_expression, jsx_attribute_name_to_prop_name, jsx_element_name_to_expression,
-    span_to_position,
+    create_ident_expression, create_ident_name, create_member_expression_from_str,
+    create_null_expression, create_num_expression, create_object_expression, create_prop_name,
+    create_str, create_str_expression, jsx_attribute_name_to_prop_name,
+    jsx_element_name_to_expression, span_to_position,
 };
 use core::str;
 use markdown::{message::Message, Location};
@@ -441,7 +441,7 @@ impl<'a> State<'a> {
                     create_str_expression("<source.js>")
                 };
                 let prop = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(create_ident("fileName").into()),
+                    key: PropName::Ident(create_ident_name("fileName")),
                     value: Box::new(filename),
                 })));
                 let mut meta_fields = vec![prop];
@@ -868,7 +868,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime automatic */\nlet a = <b />",
-                &Options::default(),
+                &Options::default()
             )?,
             "import { jsx as _jsx } from \"react/jsx-runtime\";\nlet a = _jsx(\"b\", {});\n",
             "should support a `@jsxRuntime automatic` directive"
@@ -882,7 +882,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic */\nlet a = <b />",
-                &Options::default(),
+                &Options::default()
             )?,
             "let a = React.createElement(\"b\");\n",
             "should support a `@jsxRuntime classic` directive"
@@ -907,7 +907,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime unknown */\nlet a = <b />",
-                &Options::default(),
+                &Options::default()
             )
             .err()
             .unwrap()
@@ -922,7 +922,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxImportSource aaa */\nlet a = <b />",
-                &Options::default(),
+                &Options::default()
             )?,
             "import { jsx as _jsx } from \"aaa/jsx-runtime\";\nlet a = _jsx(\"b\", {});\n",
             "should support a `@jsxImportSource` directive"
@@ -936,7 +936,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic @jsx a */\nlet b = <c />",
-                &Options::default(),
+                &Options::default()
             )?,
             "let b = a(\"c\");\n",
             "should support a `@jsx` directive"
@@ -950,7 +950,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic @jsx */\nlet a = <b />",
-                &Options::default(),
+                &Options::default()
             )?,
             "let a = React.createElement(\"b\");\n",
             "should support an empty `@jsx` directive"
@@ -964,7 +964,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic @jsx a.b-c.d! */\n<x />",
-                &Options::default(),
+                &Options::default()
             )?,
             "a[\"b-c\"][\"d!\"](\"x\");\n",
             "should support an `@jsx` directive set to an invalid identifier"
@@ -978,7 +978,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic @jsxFrag a */\nlet b = <></>",
-                &Options::default(),
+                &Options::default()
             )?,
             "let b = React.createElement(a);\n",
             "should support a `@jsxFrag` directive"
@@ -992,7 +992,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic @jsxFrag */\nlet a = <></>",
-                &Options::default(),
+                &Options::default()
             )?,
             "let a = React.createElement(React.Fragment);\n",
             "should support an empty `@jsxFrag` directive"
@@ -1006,7 +1006,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/*\n first line\n @jsxRuntime classic\n */\n<b />",
-                &Options::default(),
+                &Options::default()
             )?,
             "React.createElement(\"b\");\n",
             "should support a directive on a non-first line"
@@ -1020,7 +1020,7 @@ mod tests {
         assert_eq!(
             compile(
                 "/*\n * first line\n * @jsxRuntime classic\n */\n<b />",
-                &Options::default(),
+                &Options::default()
             )?,
             "React.createElement(\"b\");\n",
             "should support a directive on an asterisk’ed line"
@@ -1056,7 +1056,7 @@ mod tests {
         assert_eq!(
             compile(
                 "<a>b</a>",
-                &Options::default(),
+                &Options::default()
             )?,
             "import { jsx as _jsx } from \"react/jsx-runtime\";\n_jsx(\"a\", {\n    children: \"b\"\n});\n",
             "should support a closed element"
@@ -1497,7 +1497,7 @@ _jsx(\"a\", {
         assert_eq!(
             compile(
                 "/* @jsxRuntime classic */\n<a b key='c' d />",
-                &Options::default(),
+                &Options::default()
             )?,
             "React.createElement(\"a\", {
     b: true,


### PR DESCRIPTION
due to `ctxt` is removed from `span` in swc 0.99.6
so we can't the magic explicit ctxt , as a workaroubd add a magic attrrubute  to jsx elemento to flag it's explicit or not.
then remove that attribute later