### PR TITLE
Update `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.18"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.100", features = [
+swc_core = { version = "0.101", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
https://github.com/swc-project/swc/pull/9421 was a breaking change (only rust API changed), and this is a PR to update `swc_core`.