### PR TITLE
Update `swc_core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "1.0.0-alpha.18"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.101", features = [
+swc_core = { version = "0.102", features = [
   "ecma_ast",
   "ecma_visit",
   "ecma_codegen",


### PR DESCRIPTION
[Addition for the support for the name cache for the minifier](https://github.com/swc-project/swc/pull/9489) was a breaking change.

