### PR TITLE
Update `swc_core` to `v3.x.x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "=1.0.0-alpha.21"
 serde = { version = "1", optional = true }
-swc_core = { version = "1.0", features = [
+swc_core = { version = "3.0", features = [
   "common",
   "ecma_ast",
   "ecma_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "=1.0.0-alpha.21"
 serde = { version = "1", optional = true }
-swc_core = { version = "0.106", features = [
+swc_core = { version = "1.0", features = [
   "common",
   "ecma_ast",
   "ecma_codegen",


### PR DESCRIPTION
It's not a stabilization of `swc_core`, but rather it's to make semver-based tools like renovate work better