### PR TITLE
Update `swc_core` to `v5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "=1.0.0-alpha.21"
 serde = { version = "1", optional = true }
-swc_core = { version = "4.0", features = [
-  "common",
+swc_core = { version = "5", features = [
   "ecma_ast",
   "ecma_codegen",
   "ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serializable = ["serde"]
 markdown = "=1.0.0-alpha.21"
 serde = { version = "1", optional = true }
 swc_core = { version = "5", features = [
+  "common",
   "ecma_ast",
   "ecma_codegen",
   "ecma_parser",


### PR DESCRIPTION
`analysis_source_file` change, which made me bump `swc_core` from v3 to v4, is now reverted with https://github.com/swc-project/swc/pull/9717 because it broke Wasm plugins. 