### PR TITLE
Export functions for each phase

### DIFF
--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -27,7 +27,7 @@
 //! SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use crate::hast;
-use crate::swc::{parse_esm_to_tree, parse_expression_to_tree};
+use crate::swc::{parse_esm_to_tree, parse_expression_to_tree, serialize};
 use crate::swc_utils::{
     create_jsx_attr_name_from_str, create_jsx_name_from_str, inter_element_whitespace,
     position_to_span,
@@ -51,6 +51,12 @@ pub struct Program {
     pub module: Module,
     /// Comments relating to AST.
     pub comments: Vec<swc_core::common::comments::Comment>,
+}
+
+impl Program {
+    pub fn serialize(&mut self) -> String {
+        serialize(&mut self.module, Some(&self.comments))
+    }
 }
 
 /// Whether we’re in HTML or SVG.

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -54,6 +54,7 @@ pub struct Program {
 }
 
 impl Program {
+    /// Serialize to JS.
     pub fn serialize(&mut self) -> String {
         serialize(&mut self.module, Some(&self.comments))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,26 @@ pub fn compile(value: &str, options: &Options) -> Result<String, message::Messag
     Ok(serialize(&mut program.module, Some(&program.comments)))
 }
 
+/// Turn markdown into a syntax tree.
+///
+/// ## Errors
+///
+/// There are several errors that can occur with how
+/// JSX, expressions, or ESM are written.
+///
+/// ## Examples
+///
+/// ```
+/// use mdxjs::{mdast_util_from_mdx, Options};
+/// # fn main() -> Result<(), markdown::message::Message> {
+///
+/// let tree = mdast_util_from_mdx("# Hey, *you*!", &Options::default())?;
+///
+/// println!("{:?}", tree);
+/// // => Root { children: [Heading { children: [Text { value: "Hey, ", position: Some(1:3-1:8 (2-7)) }, Emphasis { children: [Text { value: "you", position: Some(1:9-1:12 (8-11)) }], position: Some(1:8-1:13 (7-12)) }, Text { value: "!", position: Some(1:13-1:14 (12-13)) }], position: Some(1:1-1:14 (0-13)), depth: 1 }], position: Some(1:1-1:14 (0-13)) }
+/// # Ok(())
+/// # }
+/// ```
 pub fn mdast_util_from_mdx(
     value: &str,
     options: &Options,
@@ -114,6 +134,7 @@ pub fn mdast_util_from_mdx(
     to_mdast(value, &parse_options)
 }
 
+/// Compile hast into SWC’s ES AST.
 pub fn hast_util_to_swc(
     hast: &hast::Node,
     value: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,8 @@ pub fn compile(value: &str, options: &Options) -> Result<String, message::Messag
     let location = Location::new(value.as_bytes());
     let mut explicit_jsxs = FxHashSet::default();
     let mut program = hast_util_to_swc(&hast, options, Some(&location), &mut explicit_jsxs)?;
-    mdx_plugin_recma_document(&mut program, &options, Some(&location))?;
-    mdx_plugin_recma_jsx_rewrite(&mut program, &options, Some(&location), &explicit_jsxs)?;
+    mdx_plugin_recma_document(&mut program, options, Some(&location))?;
+    mdx_plugin_recma_jsx_rewrite(&mut program, options, Some(&location), &explicit_jsxs)?;
     Ok(serialize(&mut program.module, Some(&program.comments)))
 }
 
@@ -143,16 +143,26 @@ pub fn mdast_util_from_mdx(
 }
 
 /// Compile hast into SWC’s ES AST.
+///
+/// ## Errors
+///
+/// This project errors for many different reasons, such as syntax errors in
+/// the MDX format or misconfiguration.
 pub fn hast_util_to_swc(
     hast: &hast::Node,
     options: &Options,
     location: Option<&Location>,
     explicit_jsxs: &mut FxHashSet<Span>,
 ) -> Result<Program, markdown::message::Message> {
-    to_swc(&hast, options.filepath.clone(), location, explicit_jsxs)
+    to_swc(hast, options.filepath.clone(), location, explicit_jsxs)
 }
 
 /// Wrap the SWC ES AST nodes coming from hast into a whole document.
+///
+/// ## Errors
+///
+/// This project errors for many different reasons, such as syntax errors in
+/// the MDX format or misconfiguration.
 pub fn mdx_plugin_recma_document(
     program: &mut Program,
     options: &Options,
@@ -170,6 +180,11 @@ pub fn mdx_plugin_recma_document(
 
 /// Rewrite JSX in an MDX file so that components can be passed in and provided.
 /// Also compiles JSX to function calls unless `options.jsx` is true.
+///
+/// ## Errors
+///
+/// This project errors for many different reasons, such as syntax errors in
+/// the MDX format or misconfiguration.
 pub fn mdx_plugin_recma_jsx_rewrite(
     program: &mut Program,
     options: &Options,

--- a/src/mdast_util_to_hast.rs
+++ b/src/mdast_util_to_hast.rs
@@ -231,9 +231,10 @@ pub fn mdast_util_to_hast(mdast: &mdast::Node) -> hast::Node {
                         }));
                     }
 
-                    tail_element
-                        .children
-                        .append(&mut backreference_opt.take().unwrap());
+                    if let Some(mut backreference) = backreference_opt {
+                        backreference_opt = None;
+                        tail_element.children.append(&mut backreference);
+                    }
                 }
             }
 

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -43,7 +43,7 @@ pub fn mdx_plugin_recma_jsx_rewrite(
     program: &mut Program,
     options: &Options,
     location: Option<&Location>,
-    explicit_jsxs: FxHashSet<Span>,
+    explicit_jsxs: &FxHashSet<Span>,
 ) {
     let mut state = State {
         scopes: vec![],
@@ -137,7 +137,7 @@ struct Scope {
 }
 
 /// Context.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 struct State<'a> {
     /// Location info.
     location: Option<&'a Location>,
@@ -157,7 +157,7 @@ struct State<'a> {
     /// helper function to throw when they are missing.
     create_error_helper: bool,
 
-    explicit_jsxs: FxHashSet<Span>,
+    explicit_jsxs: &'a FxHashSet<Span>,
 }
 
 impl State<'_> {
@@ -1044,7 +1044,7 @@ mod tests {
 
         let mut program = hast_util_to_swc(&hast, filepath, Some(&location), &mut explicit_jsxs)?;
         mdx_plugin_recma_document(&mut program, &DocumentOptions::default(), Some(&location))?;
-        mdx_plugin_recma_jsx_rewrite(&mut program, options, Some(&location), explicit_jsxs);
+        mdx_plugin_recma_jsx_rewrite(&mut program, options, Some(&location), &explicit_jsxs);
         Ok(serialize(&mut program.module, Some(&program.comments)))
     }
 
@@ -1867,7 +1867,7 @@ function _missingMdxReference(id, component, place) {
                 }))))],
             },
         };
-        mdx_plugin_recma_jsx_rewrite(&mut program, &Options::default(), None, explicit_jsxs);
+        mdx_plugin_recma_jsx_rewrite(&mut program, &Options::default(), None, &explicit_jsxs);
         assert_eq!(
             serialize(&mut program.module, None),
             "let a = <b/>;\n",
@@ -1899,7 +1899,7 @@ function _missingMdxReference(id, component, place) {
                 }))))],
             },
         };
-        mdx_plugin_recma_jsx_rewrite(&mut program, &Options::default(), None, explicit_jsxs);
+        mdx_plugin_recma_jsx_rewrite(&mut program, &Options::default(), None, &explicit_jsxs);
         assert_eq!(
             serialize(&mut program.module, None),
             "let <invalid>;\n",
@@ -1931,7 +1931,7 @@ function _missingMdxReference(id, component, place) {
                 }))))],
             },
         };
-        mdx_plugin_recma_jsx_rewrite(&mut program, &Options::default(), None, explicit_jsxs);
+        mdx_plugin_recma_jsx_rewrite(&mut program, &Options::default(), None, &explicit_jsxs);
         assert_eq!(
             serialize(&mut program.module, None),
             "let a;\n",


### PR DESCRIPTION
Similar to #27 but with updated function names based on PR comments. In Parcel, we're looking to implement native support for MDX in Rust, and we'd like to avoid re-parsing since we already use SWC. See https://github.com/parcel-bundler/parcel/pull/10064

~~Second commit may be more controversial. Basically I need a way to embed JSX expressions into Hast element nodes. In Parcel, we want to collect dependencies in MDX, e.g. image references and links. To do this, we need to transform `<img src="foo.png" />` into `<img src={new URL('foo.png', import.meta.url).toString()} />`. The `URL` constructor creates a dependency in later stages.~~

~~I tried converting the `Node::Element` into a `Node::MdxJsxElement` in order to do this, but this gets treated as an "explicit" JSX element and no longer uses the injected `_components.img`. Simplest way to implement this was to add a JSX expression variant to `PropertyValue` but I could change it if there's a better way.~~