### PR TITLE
Update `swc_core` to `v10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serializable = ["serde"]
 [dependencies]
 markdown = "=1.0.0-alpha.21"
 serde = { version = "1", optional = true }
-swc_core = { version = "9", features = [
+swc_core = { version = "10", features = [
   "common",
   "ecma_ast",
   "ecma_codegen",


### PR DESCRIPTION

There was [a breaking change](https://github.com/swc-project/swc/pull/9842) due to parallelization improvement for users of `swc_ecma_utils`. 