### PR TITLE
build: Update `swc_core` to `v13`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ swc_core = { features = [
   "ecma_parser",
   "ecma_visit",
 ], version = "13" }
+rustc-hash = "2"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ swc_core = { features = [
   "ecma_codegen",
   "ecma_parser",
   "ecma_visit",
-], version = "12" }
+], version = "13" }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/hast_util_to_swc.rs
+++ b/src/hast_util_to_swc.rs
@@ -34,7 +34,7 @@ use crate::swc_utils::{
 };
 use core::str;
 use markdown::{Location, MdxExpressionKind};
-use swc_core::alloc::collections::FxHashSet;
+use rustc_hash::FxHashSet;
 use swc_core::common::Span;
 use swc_core::ecma::ast::{
     Expr, ExprStmt, JSXAttr, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! *   [`compile()`][]
 //!     — turn MDX into JavaScript
 #![deny(clippy::pedantic)]
+#![allow(clippy::implicit_hasher)]
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::struct_excessive_bools)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@ use markdown::{
     message::{self, Message},
     to_mdast, Constructs, Location, ParseOptions,
 };
-use swc_core::{alloc::collections::FxHashSet, common::Span};
+use rustc_hash::FxHashSet;
+use swc_core::common::Span;
 
 pub use crate::configuration::{MdxConstructs, MdxParseOptions, Options};
 pub use crate::mdast_util_to_hast::mdast_util_to_hast;

--- a/src/mdx_plugin_recma_document.rs
+++ b/src/mdx_plugin_recma_document.rs
@@ -569,7 +569,7 @@ mod tests {
     use crate::swc_utils::create_bool_expression;
     use markdown::{to_mdast, ParseOptions};
     use pretty_assertions::assert_eq;
-    use swc_core::alloc::collections::FxHashSet;
+    use rustc_hash::FxHashSet;
     use swc_core::ecma::ast::{
         EmptyStmt, ExportDefaultDecl, ExprStmt, JSXClosingFragment, JSXFragment,
         JSXOpeningFragment, JSXText, Module, TsInterfaceBody, TsInterfaceDecl, WhileStmt,

--- a/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -12,7 +12,7 @@ use crate::swc_utils::{
     jsx_member_to_parts, position_to_string, span_to_position,
 };
 use markdown::{unist::Position, Location};
-use swc_core::alloc::collections::FxHashSet;
+use rustc_hash::FxHashSet;
 use swc_core::common::SyntaxContext;
 use swc_core::common::{util::take::Take, Span, DUMMY_SP};
 use swc_core::ecma::ast::{
@@ -1017,6 +1017,7 @@ mod tests {
     use crate::swc_utils::create_jsx_name_from_str;
     use markdown::{to_mdast, Location, ParseOptions};
     use pretty_assertions::assert_eq;
+    use rustc_hash::FxHashSet;
     use swc_core::ecma::ast::{Invalid, JSXOpeningElement, Module};
 
     fn compile(


### PR DESCRIPTION
I updated `rustc-hash` from v1 to v2 with https://github.com/swc-project/swc/pull/9982, and it was a breaking change because SWC exposes some traits implemented on `rustc-hash::FxXX`