### PR TITLE
build: Update `swc_core` to `v21`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ swc_core = { features = [
   "ecma_codegen",
   "ecma_parser",
   "ecma_visit",
-], version = "19" }
+], version = "21" }
 rustc-hash = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
There were some breaking changes like https://github.com/swc-project/swc/pull/10297 or 	https://github.com/swc-project/swc/pull/10268, but those does not affect mdxjs-rs