### PR TITLE
build: Update `swc_core` to `v23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ swc_core = { features = [
   "ecma_codegen",
   "ecma_parser",
   "ecma_visit",
-], version = "22" }
+], version = "23" }
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
https://github.com/swc-project/swc/pull/10405 was a breaking change of `swc_common`