### PR TITLE
build: Update `swc_core` to `v24.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ swc_core = { features = [
   "ecma_codegen",
   "ecma_parser",
   "ecma_visit",
-], version = "23" }
+], version = "24" }
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
I had to publish a new version of `swc_core` to publish https://github.com/swc-project/swc/pull/10452

https://github.com/swc-project/swc/commit/41fae744facb2397606409e9a24e1db50f00b41d#commitcomment-156825424