### PR TITLE
build: Update `swc_core` to `v26`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ swc_core = { features = [
   "ecma_codegen",
   "ecma_parser",
   "ecma_visit",
-], version = "24" }
+], version = "26" }
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
With https://github.com/swc-project/swc/pull/10399, the parser of SWC is now 7% faster! But it was a breaking change.