### PR TITLE
build: Update `swc_core` to `v27`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ swc_core = { features = [
   "ecma_codegen",
   "ecma_parser",
   "ecma_visit",
-], version = "26" }
+], version = "27" }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/swc.rs
+++ b/src/swc.rs
@@ -357,7 +357,7 @@ fn create_config(source: String) -> (SourceFile, Syntax, EsVersion) {
             FileName::Anon.into(),
             false,
             FileName::Anon.into(),
-            source,
+            source.into(),
             BytePos::from_usize(1),
         ),
         // Syntax.

--- a/src/swc_util_build_jsx.rs
+++ b/src/swc_util_build_jsx.rs
@@ -820,7 +820,7 @@ mod tests {
                 FileName::Anon.into(),
                 false,
                 FileName::Anon.into(),
-                value.into(),
+                value.to_string().into(),
                 BytePos::from_usize(1),
             ),
             Syntax::Es(EsSyntax {


### PR DESCRIPTION
https://github.com/swc-project/swc/pull/10593 was a breaking change.
It improves the memory usage of SWC while generating source maps.